### PR TITLE
feat: allow saving catalog with unchanged name and resolve name colli…

### DIFF
--- a/src/Core/Pango.Application/UseCases/Password/Commands/UpdatePassword/UpdatePasswordCommandHandler.cs
+++ b/src/Core/Pango.Application/UseCases/Password/Commands/UpdatePassword/UpdatePasswordCommandHandler.cs
@@ -45,18 +45,18 @@ public class UpdatePasswordCommandHandler
 
             if (password.IsCatalog)
             {
-                string oldCatalogPath = request.CatalogPath + (string.IsNullOrEmpty(request.CatalogPath) ? string.Empty : AppConstants.CatalogDelimeter) + password.Name;
-                var catalogPasswords = await _passwordRepository.QueryAsync(p => p.CatalogPath == oldCatalogPath, context);
+                string oldCatalogPath = string.IsNullOrEmpty(password.CatalogPath) ? password.Name : $"{password.CatalogPath}{AppConstants.CatalogDelimeter}{password.Name}";
+
+                var catalogPasswords = await _passwordRepository.QueryAsync(p => p.CatalogPath == oldCatalogPath || p.CatalogPath.StartsWith(oldCatalogPath + AppConstants.CatalogDelimeter), context);
 
                 if (catalogPasswords.Any())
                 {
                     string newCatalogPath = request.CatalogPath + (string.IsNullOrEmpty(request.CatalogPath) ? string.Empty : AppConstants.CatalogDelimeter) + request.Name;
 
-                    // DS
-                    // TODO: create update(many)
                     foreach (var pwd in catalogPasswords)
                     {
-                        pwd.CatalogPath = newCatalogPath;
+                        string suffix = pwd.CatalogPath[oldCatalogPath.Length..];
+                        pwd.CatalogPath = newCatalogPath + suffix;
                         await _passwordRepository.UpdateAsync(pwd, context);
                     }
                 }

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Dialogs/ViewModels/EditPasswordCatalogDialogViewModel.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Dialogs/ViewModels/EditPasswordCatalogDialogViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Messaging;
 using Mapster;
 using MediatR;
 using Microsoft.Extensions.Logging;
+using Pango.Application.Common;
 using Pango.Application.Models;
 using Pango.Application.UseCases.Password.Commands.NewPassword;
 using Pango.Application.UseCases.Password.Commands.UpdatePassword;
@@ -64,6 +65,7 @@ public class EditPasswordCatalogDialogViewModel : ViewModelBase, IDialogViewMode
         {
             SetProperty(ref _initialCatalog, value);
             OnPropertyChanged(nameof(InitialCatalog));
+            DialogContext.RaiseDialogContentChanged(this);
         }
     }
 
@@ -87,7 +89,26 @@ public class EditPasswordCatalogDialogViewModel : ViewModelBase, IDialogViewMode
 
     public bool CanSave()
     {
-        return !string.IsNullOrWhiteSpace(NewCatalogName) && (_existingCatalogs != null && !_existingCatalogs.Contains(NewCatalogName));
+        string separator = AppConstants.CatalogDelimeter.ToString();
+        string proposedPath = string.IsNullOrEmpty(InitialCatalog)
+            ? NewCatalogName
+            : $"{InitialCatalog}{separator}{NewCatalogName}";
+
+        var catalogs = AvailableCatalogs ?? Enumerable.Empty<string>();
+
+        bool isPathFree = IsNew
+            ? !catalogs.Contains(proposedPath, StringComparer.OrdinalIgnoreCase)
+            : (proposedPath.Equals(GetCurrentFullPath(), StringComparison.OrdinalIgnoreCase) || !catalogs.Contains(proposedPath, StringComparer.OrdinalIgnoreCase));
+
+        return !string.IsNullOrWhiteSpace(NewCatalogName) && isPathFree;
+    }
+
+    private string GetCurrentFullPath()
+    {
+        if (_selectedCatalog == null) return string.Empty;
+        return string.IsNullOrEmpty(_selectedCatalog.CatalogPath)
+            ? _selectedCatalog.Name
+            : $"{_selectedCatalog.CatalogPath}{AppConstants.CatalogDelimeter}{_selectedCatalog.Name}";
     }
 
     public void Initialize(EditCatalogParameters editCatalogParameters)
@@ -96,12 +117,26 @@ public class EditPasswordCatalogDialogViewModel : ViewModelBase, IDialogViewMode
 
         _selectedCatalog = editCatalogParameters.SelectedCatalog;
         _existingCatalogs = editCatalogParameters.ExistingCatalogs;
+        IsNew = editCatalogParameters!.SelectedCatalog is null;
 
-        AvailableCatalogs = editCatalogParameters.AllAvailableCatalogs ?? [];
+        var allCatalogs = editCatalogParameters.AllAvailableCatalogs ?? [];
+
+        if (!IsNew && _selectedCatalog != null)
+        {
+            string currentPath = GetCurrentFullPath();
+            string childPrefix = $"{currentPath}{AppConstants.CatalogDelimeter}";
+
+            AvailableCatalogs = [.. allCatalogs
+                .Where(c => !c.Equals(currentPath, StringComparison.OrdinalIgnoreCase) &&
+                            !c.StartsWith(childPrefix, StringComparison.OrdinalIgnoreCase))];
+        }
+        else
+        {
+            AvailableCatalogs = allCatalogs;
+        }
+
         NewCatalogName = editCatalogParameters.SelectedCatalog?.Name ?? string.Empty;
         InitialCatalog = editCatalogParameters.SelectedCatalog?.CatalogPath ?? editCatalogParameters?.DefaultCatalog ?? string.Empty;
-
-        IsNew = editCatalogParameters!.SelectedCatalog is null;
     }
 
     public Task OnCancelAsync()

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/PasswordsViewModel.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/PasswordsViewModel.cs
@@ -227,16 +227,16 @@ public sealed class PasswordsViewModel : ViewModelBase
 
     private async void OnEditPasswordAsync(PangoExplorerItem? selected)
     {
-        if(selected is null)
+        if (selected is null)
         {
             return;
         }
 
-        if(selected.Type == PangoExplorerItem.ExplorerItemType.Folder)
+        if (selected.Type == PangoExplorerItem.ExplorerItemType.Folder)
         {
             await _dialogService
                 .ShowNewCatalogDialogAsync(
-                    new EditCatalogParameters(GetAvailableCatalogs(), GetPathToSelectedFolder(), selected, (selected?.Parent?.Children ?? Passwords)?.Select(c => c.Name).ToList() ?? []));
+                    new EditCatalogParameters(GetAvailableCatalogs(), GetPathToSelectedFolder(), selected, (selected?.Parent?.Children ?? Passwords)?.Where(c => c.Type == PangoExplorerItem.ExplorerItemType.Folder).Select(c => c.Name).ToList() ?? []));
         }
         else
         {
@@ -253,7 +253,7 @@ public sealed class PasswordsViewModel : ViewModelBase
     {
         await _dialogService
             .ShowNewCatalogDialogAsync(
-                new EditCatalogParameters(GetAvailableCatalogs(), GetPathToSelectedFolder(), null, (SelectedItem?.Children ?? Passwords)?.Select(c => c.Name).ToList() ?? []));
+                new EditCatalogParameters(GetAvailableCatalogs(), GetPathToSelectedFolder(), null, (SelectedItem?.Children ?? Passwords)?.Where(c => c.Type == PangoExplorerItem.ExplorerItemType.Folder).Select(c => c.Name).ToList() ?? []));
     }
 
     private async void OnUpdateListAsync()

--- a/tests/Pango.Application.Tests/Password/MovePasswordsToCatalogCommandHandlerTests.cs
+++ b/tests/Pango.Application.Tests/Password/MovePasswordsToCatalogCommandHandlerTests.cs
@@ -1,0 +1,194 @@
+﻿using Microsoft.Extensions.Logging;
+using Moq;
+using Pango.Application.Common;
+using Pango.Application.Common.Interfaces.Persistence;
+using Pango.Application.Common.Interfaces.Services;
+using Pango.Application.UseCases.Password.Commands.MovePasswordsToCatalog;
+using Pango.Domain.Entities;
+
+namespace Pango.Application.Tests.Password;
+
+public class MovePasswordsToCatalogCommandHandlerTests
+{
+    private readonly Mock<IPasswordRepository> _mockPasswordRepository;
+    private readonly Mock<IUserContextProvider> _mockUserContextProvider;
+    private readonly Mock<IRepositoryContextFactory> _mockRepositoryContextFactory;
+    private readonly Mock<ILogger<MovePasswordsToCatalogCommandHandler>> _mockLogger;
+    private readonly Mock<IRepositoryActionContext> _mockContext;
+
+    public MovePasswordsToCatalogCommandHandlerTests()
+    {
+        _mockPasswordRepository = new Mock<IPasswordRepository>();
+        _mockUserContextProvider = new Mock<IUserContextProvider>();
+        _mockRepositoryContextFactory = new Mock<IRepositoryContextFactory>();
+        _mockLogger = new Mock<ILogger<MovePasswordsToCatalogCommandHandler>>();
+        _mockContext = new Mock<IRepositoryActionContext>();
+
+        // Common setup for context creation
+        _mockUserContextProvider.Setup(x => x.GetUserName()).Returns("testuser");
+        _mockUserContextProvider.Setup(x => x.GetEncodingOptionsAsync()).ReturnsAsync(new EncodingOptions("key", "salt"));
+        _mockRepositoryContextFactory
+            .Setup(x => x.Create(It.IsAny<string>(), It.IsAny<EncodingOptions>()))
+            .Returns(_mockContext.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnTrue_WhenCommandIsEmpty()
+    {
+        // Arrange
+        var command = new MovePasswordsToCatalogCommand(new Dictionary<Guid, string>());
+        var handler = GetHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsError);
+        Assert.True(result.Value);
+        _mockPasswordRepository.Verify(x => x.QueryAsync(It.IsAny<Func<PangoPassword, bool>>(), It.IsAny<IRepositoryActionContext>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnError_WhenPasswordsNotFound()
+    {
+        // Arrange
+        var passwordId = Guid.NewGuid();
+        var command = new MovePasswordsToCatalogCommand(new Dictionary<Guid, string>
+        {
+            { passwordId, "New/Path" }
+        });
+
+        // Setup repository to return empty list (password not found)
+        _mockPasswordRepository
+            .Setup(x => x.QueryAsync(It.IsAny<Func<PangoPassword, bool>>(), _mockContext.Object))
+            .ReturnsAsync(new List<PangoPassword>());
+
+        var handler = GetHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.Equal(ApplicationErrors.Password.NotFound, result.FirstError.Code);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnError_WhenCountMismatch()
+    {
+        // Arrange
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+        var command = new MovePasswordsToCatalogCommand(new Dictionary<Guid, string>
+        {
+            { id1, "Path1" },
+            { id2, "Path2" }
+        });
+
+        // Return only one password
+        var existingPassword = new PangoPassword { Id = id1 };
+        _mockPasswordRepository
+            .Setup(x => x.QueryAsync(It.IsAny<Func<PangoPassword, bool>>(), _mockContext.Object))
+            .ReturnsAsync(new List<PangoPassword> { existingPassword });
+
+        var handler = GetHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.Equal(ApplicationErrors.Password.NotFound, result.FirstError.Code);
+        Assert.Contains(id2.ToString(), result.FirstError.Description);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUpdateCatalogPaths_WhenSuccess()
+    {
+        // Arrange
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+        var newPath1 = "Folder/SubA";
+        var newPath2 = "Folder/SubB";
+
+        var command = new MovePasswordsToCatalogCommand(new Dictionary<Guid, string>
+        {
+            { id1, newPath1 },
+            { id2, newPath2 }
+        });
+
+        var pwd1 = new PangoPassword { Id = id1, CatalogPath = "OldPath" };
+        var pwd2 = new PangoPassword { Id = id2, CatalogPath = "OldPath" };
+
+        _mockPasswordRepository
+            .Setup(x => x.QueryAsync(It.IsAny<Func<PangoPassword, bool>>(), _mockContext.Object))
+            .ReturnsAsync(new List<PangoPassword> { pwd1, pwd2 });
+
+        var handler = GetHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsError);
+        Assert.True(result.Value);
+
+        // Verify objects were modified
+        Assert.Equal(newPath1, pwd1.CatalogPath);
+        Assert.Equal(newPath2, pwd2.CatalogPath);
+
+        // Verify UpdateAsync was called for both
+        _mockPasswordRepository.Verify(x => x.UpdateAsync(pwd1, _mockContext.Object), Times.Once);
+        _mockPasswordRepository.Verify(x => x.UpdateAsync(pwd2, _mockContext.Object), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnError_WhenRepositoryThrowsException()
+    {
+        // Arrange
+        var id1 = Guid.NewGuid();
+        var command = new MovePasswordsToCatalogCommand(new Dictionary<Guid, string>
+        {
+            { id1, "Path" }
+        });
+
+        var pwd1 = new PangoPassword { Id = id1 };
+
+        _mockPasswordRepository
+            .Setup(x => x.QueryAsync(It.IsAny<Func<PangoPassword, bool>>(), _mockContext.Object))
+            .ReturnsAsync(new List<PangoPassword> { pwd1 });
+
+        _mockPasswordRepository
+            .Setup(x => x.UpdateAsync(It.IsAny<PangoPassword>(), _mockContext.Object))
+            .ThrowsAsync(new Exception("Database error"));
+
+        var handler = GetHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.Equal(ApplicationErrors.Password.ModificationFailed, result.FirstError.Code);
+
+        // Verify logger was called
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => true),
+                It.IsAny<Exception>(),
+                It.Is<Func<It.IsAnyType, Exception?, string>>((v, t) => true)),
+            Times.Once);
+    }
+
+    private MovePasswordsToCatalogCommandHandler GetHandler()
+    {
+        return new MovePasswordsToCatalogCommandHandler(
+            _mockPasswordRepository.Object,
+            _mockUserContextProvider.Object,
+            _mockRepositoryContextFactory.Object,
+            _mockLogger.Object
+        );
+    }
+}


### PR DESCRIPTION
…sion bugs

fix: catalog management and validation improvements

Recursive Movement: Fixed catalog relocation to correctly move all contained files and subfolders.
Validation: Allowed saving catalog changes when only the location (parent) is modified without changing the name.
Name Collisions: Resolved issue preventing folders and keys (passwords) from having identical names in the same directory.
Bug fixes: Fixed null reference warnings and prevented selecting a child folder as a parent (circular dependency).

According to #61 #63, I think that everything has already been fixed and they should be closed

refs: #60 #61 #63