### PR TITLE
feat: Implement standalone backup service with settings UI integration

### DIFF
--- a/Pango.sln
+++ b/Pango.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31903.59
+# Visual Studio Version 18
+VisualStudioVersion = 18.2.11415.280
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pango.Application", "src\Core\Pango.Application\Pango.Application.csproj", "{346DA962-55D9-47B9-A72B-2F6BB2A9EAE8}"
 EndProject
@@ -30,6 +30,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pango.Application.Tests", "tests\Pango.Application.Tests\Pango.Application.Tests.csproj", "{5189C12E-F438-4776-9FD0-CAFA7D509383}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pango.Persistence.File", "src\Infrastructure\Pango.Persistence.File\Pango.Persistence.File.csproj", "{16697E34-A3E9-4A93-A6B8-11F653F4580A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Services", "Services", "{AF8856F8-A5EC-4413-9975-6CFC04084B30}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pango.BackupService", "src\Services\Pango.BackupService\Pango.BackupService.csproj", "{72C6AEFD-DE7F-4C9D-8C94-409A2E724AE7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -235,6 +239,26 @@ Global
 		{16697E34-A3E9-4A93-A6B8-11F653F4580A}.Release|x64.Build.0 = Release|Any CPU
 		{16697E34-A3E9-4A93-A6B8-11F653F4580A}.Release|x86.ActiveCfg = Release|Any CPU
 		{16697E34-A3E9-4A93-A6B8-11F653F4580A}.Release|x86.Build.0 = Release|Any CPU
+		{72C6AEFD-DE7F-4C9D-8C94-409A2E724AE7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{72C6AEFD-DE7F-4C9D-8C94-409A2E724AE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{72C6AEFD-DE7F-4C9D-8C94-409A2E724AE7}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{72C6AEFD-DE7F-4C9D-8C94-409A2E724AE7}.Debug|ARM.Build.0 = Debug|Any CPU
+		{72C6AEFD-DE7F-4C9D-8C94-409A2E724AE7}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{72C6AEFD-DE7F-4C9D-8C94-409A2E724AE7}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{72C6AEFD-DE7F-4C9D-8C94-409A2E724AE7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{72C6AEFD-DE7F-4C9D-8C94-409A2E724AE7}.Debug|x64.Build.0 = Debug|Any CPU
+		{72C6AEFD-DE7F-4C9D-8C94-409A2E724AE7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{72C6AEFD-DE7F-4C9D-8C94-409A2E724AE7}.Debug|x86.Build.0 = Debug|Any CPU
+		{72C6AEFD-DE7F-4C9D-8C94-409A2E724AE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{72C6AEFD-DE7F-4C9D-8C94-409A2E724AE7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{72C6AEFD-DE7F-4C9D-8C94-409A2E724AE7}.Release|ARM.ActiveCfg = Release|Any CPU
+		{72C6AEFD-DE7F-4C9D-8C94-409A2E724AE7}.Release|ARM.Build.0 = Release|Any CPU
+		{72C6AEFD-DE7F-4C9D-8C94-409A2E724AE7}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{72C6AEFD-DE7F-4C9D-8C94-409A2E724AE7}.Release|ARM64.Build.0 = Release|Any CPU
+		{72C6AEFD-DE7F-4C9D-8C94-409A2E724AE7}.Release|x64.ActiveCfg = Release|Any CPU
+		{72C6AEFD-DE7F-4C9D-8C94-409A2E724AE7}.Release|x64.Build.0 = Release|Any CPU
+		{72C6AEFD-DE7F-4C9D-8C94-409A2E724AE7}.Release|x86.ActiveCfg = Release|Any CPU
+		{72C6AEFD-DE7F-4C9D-8C94-409A2E724AE7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -249,6 +273,7 @@ Global
 		{6233D1DC-C3EA-4747-9DA7-E6ADC04DA13F} = {D55A9614-02DD-497E-9228-5012CF507EB2}
 		{5189C12E-F438-4776-9FD0-CAFA7D509383} = {D55A9614-02DD-497E-9228-5012CF507EB2}
 		{16697E34-A3E9-4A93-A6B8-11F653F4580A} = {33855C71-103E-4284-B861-A6E1E3D0E3DE}
+		{72C6AEFD-DE7F-4C9D-8C94-409A2E724AE7} = {AF8856F8-A5EC-4413-9975-6CFC04084B30}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B81B3DFC-2113-475A-97D6-5CFF5D702DBA}

--- a/src/Core/Pango.Application/Common/BackupSettings.cs
+++ b/src/Core/Pango.Application/Common/BackupSettings.cs
@@ -1,0 +1,15 @@
+﻿namespace Pango.Application.Common;
+
+public class UserBackupProfile
+{
+    public string BackupPassword { get; set; } = string.Empty;
+    public string SourceDataPath { get; set; } = string.Empty;
+}
+
+public class BackupSettings
+{
+    public string TargetFolderPath { get; set; } = string.Empty;
+    public int IntervalMinutes { get; set; } = 60;
+    public bool IsEnabled { get; set; } = true;
+    public Dictionary<string, UserBackupProfile> Users { get; set; } = [];
+}

--- a/src/Core/Pango.Application/Common/BackupSettings.cs
+++ b/src/Core/Pango.Application/Common/BackupSettings.cs
@@ -10,6 +10,7 @@ public class BackupSettings
 {
     public string TargetFolderPath { get; set; } = string.Empty;
     public int IntervalMinutes { get; set; } = 60;
+    public int RetentionDays { get; set; } = 7;
     public bool IsEnabled { get; set; } = true;
     public Dictionary<string, UserBackupProfile> Users { get; set; } = [];
 }

--- a/src/Core/Pango.Application/Common/BackupSettings.cs
+++ b/src/Core/Pango.Application/Common/BackupSettings.cs
@@ -8,9 +8,14 @@ public class UserBackupProfile
 
 public class BackupSettings
 {
+    // Constants for default configuration values
+    public const int DefaultIntervalMinutes = 60;
+    public const int DefaultRetentionDays = 7;
+    public const bool DefaultIsEnabled = true;
+
     public string TargetFolderPath { get; set; } = string.Empty;
-    public int IntervalMinutes { get; set; } = 60;
-    public int RetentionDays { get; set; } = 7;
-    public bool IsEnabled { get; set; } = true;
+    public int IntervalMinutes { get; set; } = DefaultIntervalMinutes;
+    public int RetentionDays { get; set; } = DefaultRetentionDays;
+    public bool IsEnabled { get; set; } = DefaultIsEnabled;
     public Dictionary<string, UserBackupProfile> Users { get; set; } = [];
 }

--- a/src/Core/Pango.Application/Common/Interfaces/Services/IBackupManager.cs
+++ b/src/Core/Pango.Application/Common/Interfaces/Services/IBackupManager.cs
@@ -1,0 +1,9 @@
+﻿namespace Pango.Application.Common.Interfaces.Services;
+
+// Defines the contract for backup operations
+public interface IBackupManager
+{
+    Task PerformBackupAsync(BackupSettings settings);
+    Task PerformBackupForUserAsync(string userId, string sourcePath, string targetRootPath, string backupPassword);
+    Task CleanUpOldBackupsAsync(string targetPath, string userName);
+}

--- a/src/Core/Pango.Application/Common/Interfaces/Services/IBackupManager.cs
+++ b/src/Core/Pango.Application/Common/Interfaces/Services/IBackupManager.cs
@@ -4,6 +4,8 @@
 public interface IBackupManager
 {
     Task PerformBackupAsync(BackupSettings settings);
-    Task PerformBackupForUserAsync(string userId, string sourcePath, string targetRootPath, string backupPassword);
+
+    Task PerformBackupForUserAsync(string userId, string sourcePath, string targetRootPath, string backupPassword, int retentionDays);
+
     Task CleanUpOldBackupsAsync(string targetPath, string userName);
 }

--- a/src/Core/Pango.Application/Common/Interfaces/Services/IBackupManager.cs
+++ b/src/Core/Pango.Application/Common/Interfaces/Services/IBackupManager.cs
@@ -3,8 +3,6 @@
 // Defines the contract for backup operations
 public interface IBackupManager
 {
-    Task PerformBackupAsync(BackupSettings settings);
-
     Task PerformBackupForUserAsync(string userId, string sourcePath, string targetRootPath, string backupPassword, int retentionDays);
 
     Task CleanUpOldBackupsAsync(string targetPath, string userName);

--- a/src/Core/Pango.Application/Common/Interfaces/Services/IDataImporter.cs
+++ b/src/Core/Pango.Application/Common/Interfaces/Services/IDataImporter.cs
@@ -6,4 +6,8 @@ namespace Pango.Application.Common.Interfaces.Services;
 public interface IDataImporter
 {
     public Task<ImportResultDto> ImportAsync(string filePath, IImportOptions importOptions);
+
+    Task<PangoPackageManifest> ReadManifestAsync(string filePath, IImportOptions importOptions);
+
+    Task<List<IContentPackage>> ExtractContentAsync(string filePath, IImportOptions importOptions);
 }

--- a/src/Core/Pango.Application/UseCases/Data/Commands/Import/ImportDataCommand.cs
+++ b/src/Core/Pango.Application/UseCases/Data/Commands/Import/ImportDataCommand.cs
@@ -4,15 +4,10 @@ using Pango.Application.Common.Interfaces.Persistence;
 
 namespace Pango.Application.UseCases.Data.Commands.Import;
 
-public class ImportDataCommand : IRequest<ErrorOr<ImportResult>>
+public class ImportDataCommand(string sourcePath, IImportOptions options, List<Guid>? selectedIds = null, bool importToSeparateFolder = false) : IRequest<ErrorOr<ImportResult>>
 {
-    public ImportDataCommand(string sourcePath, IImportOptions options)
-    {
-        SourcePath = sourcePath;
-        Options = options;
-    }
-
-    public string SourcePath { get; }
-    
-    public IImportOptions Options { get; }
+    public string SourcePath { get; } = sourcePath;
+    public IImportOptions Options { get; } = options;
+    public List<Guid>? SelectedIds { get; } = selectedIds;
+    public bool ImportToSeparateFolder { get; } = importToSeparateFolder;
 }

--- a/src/Core/Pango.Application/UseCases/Data/Commands/Import/ImportDataCommandHandler.cs
+++ b/src/Core/Pango.Application/UseCases/Data/Commands/Import/ImportDataCommandHandler.cs
@@ -1,12 +1,13 @@
 ﻿using ErrorOr;
+using Mapster;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using Pango.Application.Common;
-using Pango.Application.Common.Exceptions;
 using Pango.Application.Common.Interfaces.Persistence;
 using Pango.Application.Common.Interfaces.Services;
 using Pango.Application.Models;
 using Pango.Domain.Entities;
+using System.Globalization;
 
 namespace Pango.Application.UseCases.Data.Commands.Import;
 
@@ -17,68 +18,186 @@ public class ImportDataCommandHandler(
     IUserContextProvider userContextProvider,
     ILogger<ImportDataCommandHandler> logger) : IRequestHandler<ImportDataCommand, ErrorOr<ImportResult>>
 {
-    private readonly IDataImporter _dataImporter = dataImporter;
-    private readonly IPasswordRepository _passwordRepository = passwordRepository;
-    private readonly IRepositoryContextFactory _repositoryContextFactory = repositoryContextFactory;
-    private readonly IUserContextProvider _userContextProvider = userContextProvider;
-    private readonly ILogger _logger = logger;
-
     public async Task<ErrorOr<ImportResult>> Handle(ImportDataCommand request, CancellationToken cancellationToken)
     {
         try
         {
-            ImportResultDto result = await _dataImporter.ImportAsync(request.SourcePath, request.Options);
+            ImportResultDto result = await dataImporter.ImportAsync(request.SourcePath, request.Options);
             if (result is null) return Error.Failure(ApplicationErrors.Data.ImportError, "Import result is null");
 
-            var context = _repositoryContextFactory.Create(_userContextProvider.GetUserName(), await _userContextProvider.GetEncodingOptionsAsync());
-            var existingItems = (await _passwordRepository.QueryAsync(p => true, context)).ToList();
+            var context = repositoryContextFactory.Create(userContextProvider.GetUserName(), await userContextProvider.GetEncodingOptionsAsync());
+            string? importRootFolder = null;
+
+            // Import into separate folder (original behavior)
+            if (request.ImportToSeparateFolder)
+            {
+                var culture = CultureInfo.CurrentUICulture.Name;
+                string baseFolderName = culture.StartsWith("be", StringComparison.OrdinalIgnoreCase) ? "Імпартаванае" : "Imported";
+                string finalFolderName = baseFolderName;
+                var allRootFolders = (await passwordRepository.QueryAsync(p => p.IsCatalog && string.IsNullOrEmpty(p.CatalogPath), context)).Select(x => x.Name).ToList();
+                int counter = 1;
+                while (allRootFolders.Any(n => n.Equals(finalFolderName, StringComparison.OrdinalIgnoreCase)))
+                {
+                    finalFolderName = $"{baseFolderName} ({counter})";
+                    counter++;
+                }
+                var rootFolderNode = new PangoPassword
+                {
+                    Id = Guid.NewGuid(),
+                    Name = finalFolderName,
+                    IsCatalog = true,
+                    CatalogPath = string.Empty,
+                    UserName = userContextProvider.GetUserName(),
+                    CreatedAt = DateTimeOffset.UtcNow
+                };
+                await passwordRepository.CreateAsync(rootFolderNode, context);
+                importRootFolder = rootFolderNode.Name;
+            }
+            // Import into root catalog
+            else
+            {
+                string? sourceRootName = null;
+                foreach (IContentPackage package in result.ContentPackages)
+                {
+                    if (package.ContentType == Domain.Enums.ContentType.Passwords && package.Data is IEnumerable<PangoPassword> importedItems)
+                    {
+                        var rootItems = importedItems.Where(x => string.IsNullOrEmpty(x.CatalogPath)).ToList();
+                        if (rootItems.Any()) { sourceRootName = rootItems.First().Name; break; }
+                    }
+                }
+
+                if (!string.IsNullOrEmpty(sourceRootName))
+                {
+                    var allRootFolders = (await passwordRepository.QueryAsync(p => p.IsCatalog && string.IsNullOrEmpty(p.CatalogPath), context)).Select(x => x.Name).ToList();
+                    string finalRootName = sourceRootName;
+                    int counter = 1;
+                    while (allRootFolders.Any(n => n.Equals(finalRootName, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        finalRootName = $"{sourceRootName} ({counter})";
+                        counter++;
+                    }
+                    var rootFolderNode = new PangoPassword
+                    {
+                        Id = Guid.NewGuid(),
+                        Name = finalRootName,
+                        IsCatalog = true,
+                        CatalogPath = string.Empty,
+                        UserName = userContextProvider.GetUserName(),
+                        CreatedAt = DateTimeOffset.UtcNow
+                    };
+                    await passwordRepository.CreateAsync(rootFolderNode, context);
+                    importRootFolder = finalRootName;
+                }
+            }
+
+            List<PangoPassword> itemsToCreate = [];
+            HashSet<string> importedCatalogsLookup = new(StringComparer.OrdinalIgnoreCase);
 
             foreach (IContentPackage package in result.ContentPackages)
             {
-                if (package.ContentType == Domain.Enums.ContentType.Passwords)
+                if (package.ContentType == Domain.Enums.ContentType.Passwords && package.Data is IEnumerable<PangoPassword> importedItems)
                 {
-                    if (package.Data is not IEnumerable<PangoPassword> importedItems) continue;
+                    var allSourceList = importedItems.ToList();
+                    HashSet<Guid> selectedIdsSet = request.SelectedIds?.Any() == true ? GetSelectedIdsWithParents(allSourceList, [.. request.SelectedIds]) : [.. allSourceList.Select(x => x.Id)];
+                    var itemsToProcess = allSourceList.Where(x => selectedIdsSet.Contains(x.Id)).ToList();
+                    var processedItems = ReconstructHierarchy(itemsToProcess, importRootFolder);
 
-                    List<PangoPassword> itemsToAdd = [];
-                    foreach (var newItem in importedItems)
+                    foreach (var newItem in processedItems)
                     {
-                        string newPath = newItem.CatalogPath ?? string.Empty;
-
-                        bool alreadyExists = existingItems.Any(existing => {
-                            bool samePath = (existing.CatalogPath ?? string.Empty).Equals(newPath, StringComparison.OrdinalIgnoreCase);
-                            bool sameName = existing.Name.Equals(newItem.Name, StringComparison.OrdinalIgnoreCase);
-
-                            if (!samePath || !sameName) return false;
-                            if (newItem.IsCatalog != existing.IsCatalog) return false;
-                            if (newItem.IsCatalog) return true;
-
-                            return (existing.Login ?? string.Empty).Equals(newItem.Login ?? string.Empty, StringComparison.OrdinalIgnoreCase);
-                        });
-
-                        if (!alreadyExists)
+                        if (string.IsNullOrWhiteSpace(newItem.Name)) continue;
+                        if (newItem.IsCatalog)
                         {
-                            newItem.Id = Guid.NewGuid();
-                            newItem.UserName = _userContextProvider.GetUserName();
-                            itemsToAdd.Add(newItem);
-                            existingItems.Add(newItem);
+                            string catalogKey = GetUniqueCatalogKey(newItem);
+                            if (importedCatalogsLookup.Contains(catalogKey)) continue;
+                            importedCatalogsLookup.Add(catalogKey);
                         }
-                    }
-
-                    if (itemsToAdd.Any())
-                    {
-                        await _passwordRepository.CreateAsync(itemsToAdd, context);
+                        newItem.Id = Guid.NewGuid();
+                        newItem.UserName = userContextProvider.GetUserName();
+                        newItem.CreatedAt = DateTimeOffset.UtcNow;
+                        itemsToCreate.Add(newItem);
                     }
                 }
             }
+
+            if (itemsToCreate.Any()) await passwordRepository.CreateAsync(itemsToCreate, context);
             return new ImportResult(result.Manifest);
-        }
-        catch (PangoDataDecryptionException ex)
-        {
-            return Error.Failure(ex.Code, "Wrong password for the export file.");
         }
         catch (Exception ex)
         {
+            logger.LogError(ex, "Import failed");
             return Error.Failure(ApplicationErrors.Data.ImportError, ex.Message);
         }
+    }
+
+    // Generates unique key for catalog: CatalogPath|Name
+    private static string GetUniqueCatalogKey(PangoPassword item)
+    {
+        return $"{item.CatalogPath?.Trim() ?? ""}|{item.Name?.Trim() ?? ""}";
+    }
+
+    // Returns all selected IDs and their ancestors recursively
+    private static HashSet<Guid> GetSelectedIdsWithParents(List<PangoPassword> allItems, HashSet<Guid> selectedIds)
+    {
+        var result = new HashSet<Guid>(selectedIds);
+        var parentMap = BuildParentMap(allItems);
+        foreach (var selectedId in selectedIds.ToList())
+        {
+            var currentId = selectedId;
+            while (parentMap.TryGetValue(currentId, out var parentId) && parentId.HasValue)
+            {
+                if (!result.Contains(parentId.Value)) result.Add(parentId.Value);
+                currentId = parentId.Value;
+            }
+        }
+        return result;
+    }
+
+    // Builds parent-child map using CatalogPath
+    private static Dictionary<Guid, Guid?> BuildParentMap(List<PangoPassword> allItems)
+    {
+        var parentMap = new Dictionary<Guid, Guid?>();
+        var pathMap = new Dictionary<string, PangoPassword>(StringComparer.OrdinalIgnoreCase);
+        foreach (var item in allItems)
+        {
+            if (string.IsNullOrWhiteSpace(item.Name)) continue;
+            string fullPath = GetFullPath(item);
+            if (!pathMap.ContainsKey(fullPath)) pathMap[fullPath] = item;
+        }
+        foreach (var item in allItems)
+        {
+            if (string.IsNullOrEmpty(item.CatalogPath)) parentMap[item.Id] = null;
+            else
+            {
+                var parentPath = item.CatalogPath;
+                parentMap[item.Id] = pathMap.TryGetValue(parentPath, out var parent) ? parent.Id : (Guid?)null;
+            }
+        }
+        return parentMap;
+    }
+
+    // Reconstructs hierarchy: prepends forcedRoot to CatalogPath if provided
+    private static List<PangoPassword> ReconstructHierarchy(List<PangoPassword> itemsToSave, string? forcedRoot)
+    {
+        var result = new List<PangoPassword>();
+        foreach (var item in itemsToSave)
+        {
+            var newItem = item.Adapt<PangoPassword>();
+            if (!string.IsNullOrEmpty(forcedRoot))
+            {
+                newItem.CatalogPath = string.IsNullOrEmpty(item.CatalogPath) ? forcedRoot : $"{forcedRoot}{AppConstants.CatalogDelimeter}{item.CatalogPath}";
+            }
+            else
+            {
+                newItem.CatalogPath = item.CatalogPath;
+            }
+            result.Add(newItem);
+        }
+        return result;
+    }
+
+    // Builds full path: CatalogPath + Name
+    private static string GetFullPath(PangoPassword item)
+    {
+        return string.IsNullOrEmpty(item.CatalogPath) ? item.Name : $"{item.CatalogPath}{AppConstants.CatalogDelimeter}{item.Name}";
     }
 }

--- a/src/Core/Pango.Application/UseCases/Data/Commands/Import/ImportDataCommandHandler.cs
+++ b/src/Core/Pango.Application/UseCases/Data/Commands/Import/ImportDataCommandHandler.cs
@@ -10,77 +10,75 @@ using Pango.Domain.Entities;
 
 namespace Pango.Application.UseCases.Data.Commands.Import;
 
-public class ImportDataCommandHandler
-    : IRequestHandler<ImportDataCommand, ErrorOr<ImportResult>>
+public class ImportDataCommandHandler(
+    IDataImporter dataImporter,
+    IPasswordRepository passwordRepository,
+    IRepositoryContextFactory repositoryContextFactory,
+    IUserContextProvider userContextProvider,
+    ILogger<ImportDataCommandHandler> logger) : IRequestHandler<ImportDataCommand, ErrorOr<ImportResult>>
 {
-    private readonly IDataImporter _dataImporter;
-    private readonly IPasswordRepository _passwordRepository;
-    private readonly IRepositoryContextFactory _repositoryContextFactory;
-    private readonly IUserContextProvider _userContextProvider;
-    private readonly ILogger _logger;
-
-    public ImportDataCommandHandler(
-        IDataImporter dataImporter, 
-        IPasswordRepository passwordRepository, 
-        IRepositoryContextFactory repositoryContextFactory, 
-        IUserContextProvider userContextProvider,
-        ILogger<ImportDataCommandHandler> logger)
-    {
-        _logger = logger;
-        _dataImporter = dataImporter;
-        _passwordRepository = passwordRepository;
-        _repositoryContextFactory = repositoryContextFactory;
-        _userContextProvider = userContextProvider;
-    }
+    private readonly IDataImporter _dataImporter = dataImporter;
+    private readonly IPasswordRepository _passwordRepository = passwordRepository;
+    private readonly IRepositoryContextFactory _repositoryContextFactory = repositoryContextFactory;
+    private readonly IUserContextProvider _userContextProvider = userContextProvider;
+    private readonly ILogger _logger = logger;
 
     public async Task<ErrorOr<ImportResult>> Handle(ImportDataCommand request, CancellationToken cancellationToken)
     {
         try
         {
             ImportResultDto result = await _dataImporter.ImportAsync(request.SourcePath, request.Options);
+            if (result is null) return Error.Failure(ApplicationErrors.Data.ImportError, "Import result is null");
 
-            if(result is null)
+            var context = _repositoryContextFactory.Create(_userContextProvider.GetUserName(), await _userContextProvider.GetEncodingOptionsAsync());
+            var existingItems = (await _passwordRepository.QueryAsync(p => true, context)).ToList();
+
+            foreach (IContentPackage package in result.ContentPackages)
             {
-                return Error.Failure(ApplicationErrors.Data.ImportError, "Import result is null");   
-            }
-            else
-            {
-                foreach (IContentPackage package in result.ContentPackages)
+                if (package.ContentType == Domain.Enums.ContentType.Passwords)
                 {
-                    if(package.ContentType == Domain.Enums.ContentType.Passwords)
+                    if (package.Data is not IEnumerable<PangoPassword> importedItems) continue;
+
+                    List<PangoPassword> itemsToAdd = [];
+                    foreach (var newItem in importedItems)
                     {
-                        var passwords = package.Data as IEnumerable<PangoPassword>;
+                        string newPath = newItem.CatalogPath ?? string.Empty;
 
-                        if(passwords is not null && passwords.Any())
+                        bool alreadyExists = existingItems.Any(existing => {
+                            bool samePath = (existing.CatalogPath ?? string.Empty).Equals(newPath, StringComparison.OrdinalIgnoreCase);
+                            bool sameName = existing.Name.Equals(newItem.Name, StringComparison.OrdinalIgnoreCase);
+
+                            if (!samePath || !sameName) return false;
+                            if (newItem.IsCatalog != existing.IsCatalog) return false;
+                            if (newItem.IsCatalog) return true;
+
+                            return (existing.Login ?? string.Empty).Equals(newItem.Login ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+                        });
+
+                        if (!alreadyExists)
                         {
-                            // re-generate the ID to avoid collisions
-                            foreach (var item in passwords)
-                            {
-                                item.Id = Guid.NewGuid();
-                            }
-
-                            await _passwordRepository.CreateAsync(passwords, _repositoryContextFactory.Create(_userContextProvider.GetUserName(), await _userContextProvider.GetEncodingOptionsAsync()));
+                            newItem.Id = Guid.NewGuid();
+                            newItem.UserName = _userContextProvider.GetUserName();
+                            itemsToAdd.Add(newItem);
+                            existingItems.Add(newItem);
                         }
                     }
-                    else
+
+                    if (itemsToAdd.Any())
                     {
-                        throw new NotImplementedException($"Cannot parse {package.ContentType.ToString()} type. Not implemented.");
+                        await _passwordRepository.CreateAsync(itemsToAdd, context);
                     }
                 }
             }
-
             return new ImportResult(result.Manifest);
+        }
+        catch (PangoDataDecryptionException ex)
+        {
+            return Error.Failure(ex.Code, "Wrong password for the export file.");
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Data import failed: {message}", ex.Message);
-
-            if(ex is PangoException pEx)
-            {
-                return Error.Failure(pEx.Code, pEx.Message);
-            }
-
-            return Error.Failure(ApplicationErrors.Data.ImportError, $"Import failed: {ex.Message}");
+            return Error.Failure(ApplicationErrors.Data.ImportError, ex.Message);
         }
     }
 }

--- a/src/Core/Pango.Application/UseCases/Data/Commands/Import/ImportDataCommandHandler.cs
+++ b/src/Core/Pango.Application/UseCases/Data/Commands/Import/ImportDataCommandHandler.cs
@@ -62,7 +62,7 @@ public class ImportDataCommandHandler(
                     if (package.ContentType == Domain.Enums.ContentType.Passwords && package.Data is IEnumerable<PangoPassword> importedItems)
                     {
                         var rootItems = importedItems.Where(x => string.IsNullOrEmpty(x.CatalogPath)).ToList();
-                        if (rootItems.Any()) { sourceRootName = rootItems.First().Name; break; }
+                        if (rootItems.Count != 0) { sourceRootName = rootItems.First().Name; break; }
                     }
                 }
 
@@ -98,7 +98,7 @@ public class ImportDataCommandHandler(
                 if (package.ContentType == Domain.Enums.ContentType.Passwords && package.Data is IEnumerable<PangoPassword> importedItems)
                 {
                     var allSourceList = importedItems.ToList();
-                    HashSet<Guid> selectedIdsSet = request.SelectedIds?.Any() == true ? GetSelectedIdsWithParents(allSourceList, [.. request.SelectedIds]) : [.. allSourceList.Select(x => x.Id)];
+                    HashSet<Guid> selectedIdsSet = request.SelectedIds?.Count > 0 ? GetSelectedIdsWithParents(allSourceList, [.. request.SelectedIds]) : [.. allSourceList.Select(x => x.Id)];
                     var itemsToProcess = allSourceList.Where(x => selectedIdsSet.Contains(x.Id)).ToList();
                     var processedItems = ReconstructHierarchy(itemsToProcess, importRootFolder);
 
@@ -119,7 +119,7 @@ public class ImportDataCommandHandler(
                 }
             }
 
-            if (itemsToCreate.Any()) await passwordRepository.CreateAsync(itemsToCreate, context);
+            if (itemsToCreate.Count != 0) await passwordRepository.CreateAsync(itemsToCreate, context);
             return new ImportResult(result.Manifest);
         }
         catch (Exception ex)
@@ -129,13 +129,17 @@ public class ImportDataCommandHandler(
         }
     }
 
-    // Generates unique key for catalog: CatalogPath|Name
+    /// <summary>
+    /// Generates a unique catalog key using CatalogPath and Name, separated by '|'.
+    /// </summary>
     private static string GetUniqueCatalogKey(PangoPassword item)
     {
-        return $"{item.CatalogPath?.Trim() ?? ""}|{item.Name?.Trim() ?? ""}";
+        return $"{item.CatalogPath?.Trim() ?? string.Empty}|{item.Name?.Trim() ?? string.Empty}";
     }
 
-    // Returns all selected IDs and their ancestors recursively
+    /// <summary>
+    /// Returns all selected IDs and their parent IDs recursively up the hierarchy.
+    /// </summary>
     private static HashSet<Guid> GetSelectedIdsWithParents(List<PangoPassword> allItems, HashSet<Guid> selectedIds)
     {
         var result = new HashSet<Guid>(selectedIds);
@@ -152,7 +156,9 @@ public class ImportDataCommandHandler(
         return result;
     }
 
-    // Builds parent-child map using CatalogPath
+    /// <summary>
+    /// Builds a parent-child mapping using CatalogPath to identify hierarchical relationships.
+    /// </summary>
     private static Dictionary<Guid, Guid?> BuildParentMap(List<PangoPassword> allItems)
     {
         var parentMap = new Dictionary<Guid, Guid?>();
@@ -175,7 +181,9 @@ public class ImportDataCommandHandler(
         return parentMap;
     }
 
-    // Reconstructs hierarchy: prepends forcedRoot to CatalogPath if provided
+    /// <summary>
+    /// Reconstructs the item hierarchy by prepending a forced root path to CatalogPath.
+    /// </summary>
     private static List<PangoPassword> ReconstructHierarchy(List<PangoPassword> itemsToSave, string? forcedRoot)
     {
         var result = new List<PangoPassword>();
@@ -195,7 +203,9 @@ public class ImportDataCommandHandler(
         return result;
     }
 
-    // Builds full path: CatalogPath + Name
+    /// <summary>
+    /// Constructs the full path of an item by combining CatalogPath and Name.
+    /// </summary>
     private static string GetFullPath(PangoPassword item)
     {
         return string.IsNullOrEmpty(item.CatalogPath) ? item.Name : $"{item.CatalogPath}{AppConstants.CatalogDelimeter}{item.Name}";

--- a/src/Core/Pango.Application/UseCases/Data/Commands/Import/ImportDataCommandHandler.cs
+++ b/src/Core/Pango.Application/UseCases/Data/Commands/Import/ImportDataCommandHandler.cs
@@ -18,6 +18,9 @@ public class ImportDataCommandHandler(
     IUserContextProvider userContextProvider,
     ILogger<ImportDataCommandHandler> logger) : IRequestHandler<ImportDataCommand, ErrorOr<ImportResult>>
 {
+    /// <summary> 
+    /// Handles importing password data from external sources into the repository. 
+    /// </summary>
     public async Task<ErrorOr<ImportResult>> Handle(ImportDataCommand request, CancellationToken cancellationToken)
     {
         try
@@ -26,98 +29,9 @@ public class ImportDataCommandHandler(
             if (result is null) return Error.Failure(ApplicationErrors.Data.ImportError, "Import result is null");
 
             var context = repositoryContextFactory.Create(userContextProvider.GetUserName(), await userContextProvider.GetEncodingOptionsAsync());
-            string? importRootFolder = null;
+            string? importRootFolder = await GetImportRootFolderAsync(request, result, context);
 
-            // Import into separate folder (original behavior)
-            if (request.ImportToSeparateFolder)
-            {
-                var culture = CultureInfo.CurrentUICulture.Name;
-                string baseFolderName = culture.StartsWith("be", StringComparison.OrdinalIgnoreCase) ? "Імпартаванае" : "Imported";
-                string finalFolderName = baseFolderName;
-                var allRootFolders = (await passwordRepository.QueryAsync(p => p.IsCatalog && string.IsNullOrEmpty(p.CatalogPath), context)).Select(x => x.Name).ToList();
-                int counter = 1;
-                while (allRootFolders.Any(n => n.Equals(finalFolderName, StringComparison.OrdinalIgnoreCase)))
-                {
-                    finalFolderName = $"{baseFolderName} ({counter})";
-                    counter++;
-                }
-                var rootFolderNode = new PangoPassword
-                {
-                    Id = Guid.NewGuid(),
-                    Name = finalFolderName,
-                    IsCatalog = true,
-                    CatalogPath = string.Empty,
-                    UserName = userContextProvider.GetUserName(),
-                    CreatedAt = DateTimeOffset.UtcNow
-                };
-                await passwordRepository.CreateAsync(rootFolderNode, context);
-                importRootFolder = rootFolderNode.Name;
-            }
-            // Import into root catalog
-            else
-            {
-                string? sourceRootName = null;
-                foreach (IContentPackage package in result.ContentPackages)
-                {
-                    if (package.ContentType == Domain.Enums.ContentType.Passwords && package.Data is IEnumerable<PangoPassword> importedItems)
-                    {
-                        var rootItems = importedItems.Where(x => string.IsNullOrEmpty(x.CatalogPath)).ToList();
-                        if (rootItems.Count != 0) { sourceRootName = rootItems.First().Name; break; }
-                    }
-                }
-
-                if (!string.IsNullOrEmpty(sourceRootName))
-                {
-                    var allRootFolders = (await passwordRepository.QueryAsync(p => p.IsCatalog && string.IsNullOrEmpty(p.CatalogPath), context)).Select(x => x.Name).ToList();
-                    string finalRootName = sourceRootName;
-                    int counter = 1;
-                    while (allRootFolders.Any(n => n.Equals(finalRootName, StringComparison.OrdinalIgnoreCase)))
-                    {
-                        finalRootName = $"{sourceRootName} ({counter})";
-                        counter++;
-                    }
-                    var rootFolderNode = new PangoPassword
-                    {
-                        Id = Guid.NewGuid(),
-                        Name = finalRootName,
-                        IsCatalog = true,
-                        CatalogPath = string.Empty,
-                        UserName = userContextProvider.GetUserName(),
-                        CreatedAt = DateTimeOffset.UtcNow
-                    };
-                    await passwordRepository.CreateAsync(rootFolderNode, context);
-                    importRootFolder = finalRootName;
-                }
-            }
-
-            List<PangoPassword> itemsToCreate = [];
-            HashSet<string> importedCatalogsLookup = new(StringComparer.OrdinalIgnoreCase);
-
-            foreach (IContentPackage package in result.ContentPackages)
-            {
-                if (package.ContentType == Domain.Enums.ContentType.Passwords && package.Data is IEnumerable<PangoPassword> importedItems)
-                {
-                    var allSourceList = importedItems.ToList();
-                    HashSet<Guid> selectedIdsSet = request.SelectedIds?.Count > 0 ? GetSelectedIdsWithParents(allSourceList, [.. request.SelectedIds]) : [.. allSourceList.Select(x => x.Id)];
-                    var itemsToProcess = allSourceList.Where(x => selectedIdsSet.Contains(x.Id)).ToList();
-                    var processedItems = ReconstructHierarchy(itemsToProcess, importRootFolder);
-
-                    foreach (var newItem in processedItems)
-                    {
-                        if (string.IsNullOrWhiteSpace(newItem.Name)) continue;
-                        if (newItem.IsCatalog)
-                        {
-                            string catalogKey = GetUniqueCatalogKey(newItem);
-                            if (importedCatalogsLookup.Contains(catalogKey)) continue;
-                            importedCatalogsLookup.Add(catalogKey);
-                        }
-                        newItem.Id = Guid.NewGuid();
-                        newItem.UserName = userContextProvider.GetUserName();
-                        newItem.CreatedAt = DateTimeOffset.UtcNow;
-                        itemsToCreate.Add(newItem);
-                    }
-                }
-            }
+            List<PangoPassword> itemsToCreate = ProcessPackages(result.ContentPackages, request, importRootFolder);
 
             if (itemsToCreate.Count != 0) await passwordRepository.CreateAsync(itemsToCreate, context);
             return new ImportResult(result.Manifest);
@@ -129,7 +43,104 @@ public class ImportDataCommandHandler(
         }
     }
 
-    /// <summary>
+    /// <summary> 
+    /// Determines the root folder name for imported items based on import options and source structure. 
+    /// </summary>
+    private async Task<string?> GetImportRootFolderAsync(ImportDataCommand request, ImportResultDto result, IRepositoryActionContext context)
+    {
+        if (request.ImportToSeparateFolder)
+        {
+            var culture = CultureInfo.CurrentUICulture.Name;
+            string baseFolderName = culture.StartsWith("be", StringComparison.OrdinalIgnoreCase) ? "Імпартаванае" : "Imported";
+            return await CreateUniqueRootFolderAsync(baseFolderName, context);
+        }
+        else
+        {
+            string? sourceRootName = null;
+            foreach (IContentPackage package in result.ContentPackages)
+            {
+                if (package.ContentType == Domain.Enums.ContentType.Passwords && package.Data is IEnumerable<PangoPassword> importedItems)
+                {
+                    var rootItems = importedItems.Where(x => string.IsNullOrEmpty(x.CatalogPath)).ToList();
+                    if (rootItems.Count != 0) { sourceRootName = rootItems.First().Name; break; }
+                }
+            }
+
+            if (!string.IsNullOrEmpty(sourceRootName))
+            {
+                return await CreateUniqueRootFolderAsync(sourceRootName, context);
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary> 
+    /// Creates a unique root folder name by appending a numeric suffix if needed and persists it. 
+    /// </summary>
+    private async Task<string> CreateUniqueRootFolderAsync(string baseName, IRepositoryActionContext context)
+    {
+        var allRootFolders = (await passwordRepository.QueryAsync(p => p.IsCatalog && string.IsNullOrEmpty(p.CatalogPath), context))
+                             .Select(x => x.Name).ToList();
+
+        string finalName = baseName;
+        int counter = 1;
+        while (allRootFolders.Any(n => n.Equals(finalName, StringComparison.OrdinalIgnoreCase)))
+        {
+            finalName = $"{baseName} ({counter})";
+            counter++;
+        }
+
+        var rootFolderNode = new PangoPassword
+        {
+            Id = Guid.NewGuid(),
+            Name = finalName,
+            IsCatalog = true,
+            CatalogPath = string.Empty,
+            UserName = userContextProvider.GetUserName(),
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        await passwordRepository.CreateAsync(rootFolderNode, context);
+        return finalName;
+    }
+
+    /// <summary> 
+    /// Processes imported content packages, filters selected items, and reconstructs hierarchy. 
+    /// </summary>
+    private List<PangoPassword> ProcessPackages(IEnumerable<IContentPackage> packages, ImportDataCommand request, string? importRootFolder)
+    {
+        List<PangoPassword> itemsToCreate = [];
+        HashSet<string> importedCatalogsLookup = new(StringComparer.OrdinalIgnoreCase);
+
+        foreach (IContentPackage package in packages)
+        {
+            if (package.ContentType == Domain.Enums.ContentType.Passwords && package.Data is IEnumerable<PangoPassword> importedItems)
+            {
+                var allSourceList = importedItems.ToList();
+                HashSet<Guid> selectedIdsSet = request.SelectedIds?.Count > 0 ? GetSelectedIdsWithParents(allSourceList, [.. request.SelectedIds]) : [.. allSourceList.Select(x => x.Id)];
+                var itemsToProcess = allSourceList.Where(x => selectedIdsSet.Contains(x.Id)).ToList();
+                var processedItems = ReconstructHierarchy(itemsToProcess, importRootFolder);
+
+                foreach (var newItem in processedItems)
+                {
+                    if (string.IsNullOrWhiteSpace(newItem.Name)) continue;
+                    if (newItem.IsCatalog)
+                    {
+                        string catalogKey = GetUniqueCatalogKey(newItem);
+                        if (importedCatalogsLookup.Contains(catalogKey)) continue;
+                        importedCatalogsLookup.Add(catalogKey);
+                    }
+                    newItem.Id = Guid.NewGuid();
+                    newItem.UserName = userContextProvider.GetUserName();
+                    newItem.CreatedAt = DateTimeOffset.UtcNow;
+                    itemsToCreate.Add(newItem);
+                }
+            }
+        }
+        return itemsToCreate;
+    }
+
+    /// <summary> 
     /// Generates a unique catalog key using CatalogPath and Name, separated by '|'.
     /// </summary>
     private static string GetUniqueCatalogKey(PangoPassword item)
@@ -137,7 +148,7 @@ public class ImportDataCommandHandler(
         return $"{item.CatalogPath?.Trim() ?? string.Empty}|{item.Name?.Trim() ?? string.Empty}";
     }
 
-    /// <summary>
+    /// <summary> 
     /// Returns all selected IDs and their parent IDs recursively up the hierarchy.
     /// </summary>
     private static HashSet<Guid> GetSelectedIdsWithParents(List<PangoPassword> allItems, HashSet<Guid> selectedIds)
@@ -156,7 +167,7 @@ public class ImportDataCommandHandler(
         return result;
     }
 
-    /// <summary>
+    /// <summary> 
     /// Builds a parent-child mapping using CatalogPath to identify hierarchical relationships.
     /// </summary>
     private static Dictionary<Guid, Guid?> BuildParentMap(List<PangoPassword> allItems)
@@ -181,12 +192,12 @@ public class ImportDataCommandHandler(
         return parentMap;
     }
 
-    /// <summary>
+    /// <summary> 
     /// Reconstructs the item hierarchy by prepending a forced root path to CatalogPath.
     /// </summary>
     private static List<PangoPassword> ReconstructHierarchy(List<PangoPassword> itemsToSave, string? forcedRoot)
     {
-        var result = new List<PangoPassword>();
+        var result = new List<PangoPassword>(itemsToSave.Count);
         foreach (var item in itemsToSave)
         {
             var newItem = item.Adapt<PangoPassword>();

--- a/src/Infrastructure/Pango.Infrastructure/Services/BackupManager.cs
+++ b/src/Infrastructure/Pango.Infrastructure/Services/BackupManager.cs
@@ -9,8 +9,19 @@ namespace Pango.Infrastructure.Services;
 
 public class BackupManager(ILogger<BackupManager> logger) : IBackupManager
 {
+    /// <summary>
+    /// The default number of days to retain backup files before deletion.
+    /// </summary>
     private const int DefaultRetentionDays = 7;
+
+    /// <summary>
+    /// The length of the timestamp prefix in the backup filename (yyyy-MM-dd_HH-mm-ss).
+    /// </summary>
     private const int TimestampPrefixLength = 19;
+
+    /// <summary>
+    /// The date format string used for timestamping backup files.
+    /// </summary>
     private const string DateFormat = "yyyy-MM-dd_HH-mm-ss";
 
     private readonly ILogger<BackupManager> _logger = logger;
@@ -18,6 +29,11 @@ public class BackupManager(ILogger<BackupManager> logger) : IBackupManager
     /// <summary>
     /// Orchestrates the backup process: zips, encrypts, and rotates old files.
     /// </summary>
+    /// <param name="userId">The unique identifier of the user.</param>
+    /// <param name="sourcePath">The directory path to back up.</param>
+    /// <param name="targetRootPath">The destination directory for the backup.</param>
+    /// <param name="backupPassword">The password used for encryption.</param>
+    /// <param name="retentionDays">Number of days to keep old backups.</param>
     public async Task PerformBackupForUserAsync(string userId, string sourcePath, string targetRootPath, string backupPassword, int retentionDays)
     {
         try
@@ -30,7 +46,7 @@ public class BackupManager(ILogger<BackupManager> logger) : IBackupManager
             string tempZipPath = targetFilePath + ".tmp";
 
             if (File.Exists(tempZipPath)) File.Delete(tempZipPath);
-            ZipFile.CreateFromDirectory(sourcePath, tempZipPath);
+            await Task.Run(() => ZipFile.CreateFromDirectory(sourcePath, tempZipPath));
 
             await EncryptFileAsync(tempZipPath, targetFilePath, backupPassword);
 
@@ -65,6 +81,9 @@ public class BackupManager(ILogger<BackupManager> logger) : IBackupManager
     /// <summary>
     /// Encrypts a file using AES-256 with Pbkdf2 key derivation.
     /// </summary>
+    /// <param name="inputFile">The path to the source file (plaintext).</param>
+    /// <param name="outputFile">The path to the destination file (encrypted).</param>
+    /// <param name="password">The password used to derive the encryption key.</param>
     private static async Task EncryptFileAsync(string inputFile, string outputFile, string password)
     {
         // 1. Generate random Salt (16 bytes)
@@ -72,7 +91,8 @@ public class BackupManager(ILogger<BackupManager> logger) : IBackupManager
         using (var rng = RandomNumberGenerator.Create()) { rng.GetBytes(salt); }
 
         // 2. Derive Key and IV from Password and Salt
-        byte[] derivedBytes = Rfc2898DeriveBytes.Pbkdf2(Encoding.UTF8.GetBytes(password), salt, 50000, HashAlgorithmName.SHA256, 48);
+        byte[] derivedBytes = await Task.Run(() =>
+            Rfc2898DeriveBytes.Pbkdf2(Encoding.UTF8.GetBytes(password), salt, 50000, HashAlgorithmName.SHA256, 48));
 
         using var aes = Aes.Create();
         aes.Key = derivedBytes[0..32];
@@ -97,6 +117,8 @@ public class BackupManager(ILogger<BackupManager> logger) : IBackupManager
     /// <summary>
     /// Overload for cleanup using the default retention period.
     /// </summary>
+    /// <param name="targetPath">The directory containing backups.</param>
+    /// <param name="userName">The user identifier to filter files.</param>
     public Task CleanUpOldBackupsAsync(string targetPath, string userName)
     {
         return CleanUpOldBackupsAsync(targetPath, userName, DefaultRetentionDays);
@@ -105,55 +127,59 @@ public class BackupManager(ILogger<BackupManager> logger) : IBackupManager
     /// <summary>
     /// Deletes backup files older than the specified retention days.
     /// </summary>
-    public Task CleanUpOldBackupsAsync(string targetPath, string userName, int retentionDays)
+    /// <param name="targetPath">The directory containing backups.</param>
+    /// <param name="userName">The user identifier to filter files.</param>
+    /// <param name="retentionDays">Number of days to keep old backups.</param>
+    public async Task CleanUpOldBackupsAsync(string targetPath, string userName, int retentionDays)
     {
-        try
+        await Task.Run(() =>
         {
-            if (retentionDays <= 0)
+            try
             {
-                _logger.LogDebug("Retention policy disabled. Keeping all files.");
-                return Task.CompletedTask;
-            }
-
-            DirectoryInfo dir = new(targetPath);
-            if (!dir.Exists) return Task.CompletedTask;
-
-            var files = dir.GetFiles($"*-{userName}_Backup.pngx");
-            DateTime now = DateTime.Now;
-
-            foreach (var file in files)
-            {
-                if (file.Name.Length >= TimestampPrefixLength)
+                if (retentionDays <= 0)
                 {
-                    string datePart = file.Name[..TimestampPrefixLength];
-                    if (DateTime.TryParseExact(datePart, DateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime backupDate))
-                    {
-                        double ageInDays = (now - backupDate).TotalDays;
+                    _logger.LogDebug("Retention policy disabled. Keeping all files.");
+                    return;
+                }
 
-                        if (ageInDays > retentionDays)
+                DirectoryInfo dir = new(targetPath);
+                if (!dir.Exists) return;
+
+                var files = dir.GetFiles($"*-{userName}_Backup.pngx");
+                DateTime now = DateTime.Now;
+
+                foreach (var file in files)
+                {
+                    if (file.Name.Length >= TimestampPrefixLength)
+                    {
+                        string datePart = file.Name[..TimestampPrefixLength];
+                        if (DateTime.TryParseExact(datePart, DateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime backupDate))
                         {
-                            try
+                            double ageInDays = (now - backupDate).TotalDays;
+
+                            if (ageInDays > retentionDays)
                             {
-                                file.Delete();
-                                if (_logger.IsEnabled(LogLevel.Debug))
+                                try
                                 {
-                                    _logger.LogDebug("Deleted expired backup: {Name} (Age: {Age:F1} days)", file.Name, ageInDays);
+                                    file.Delete();
+                                    if (_logger.IsEnabled(LogLevel.Debug))
+                                    {
+                                        _logger.LogDebug("Deleted expired backup: {Name} (Age: {Age:F1} days)", file.Name, ageInDays);
+                                    }
                                 }
-                            }
-                            catch (Exception delEx)
-                            {
-                                _logger.LogWarning(delEx, "Failed to delete old backup {Name}", file.Name);
+                                catch (Exception delEx)
+                                {
+                                    _logger.LogWarning(delEx, "Failed to delete old backup {Name}", file.Name);
+                                }
                             }
                         }
                     }
                 }
             }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error during retention cleanup");
-        }
-
-        return Task.CompletedTask;
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during retention cleanup");
+            }
+        });
     }
 }

--- a/src/Infrastructure/Pango.Infrastructure/Services/BackupManager.cs
+++ b/src/Infrastructure/Pango.Infrastructure/Services/BackupManager.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Pango.Application.Common;
 using Pango.Application.Common.Interfaces.Services;
+using System.Globalization;
 using System.IO.Compression;
 using System.Security.Cryptography;
 
@@ -18,40 +19,34 @@ public class BackupManager(ILogger<BackupManager> logger) : IBackupManager
     }
 
     // Main logic: Rotates files, Zips content, Encrypts Zip, and Cleans up old files
-    public async Task PerformBackupForUserAsync(string userId, string sourcePath, string targetRootPath, string backupPassword)
+    public async Task PerformBackupForUserAsync(string userId, string sourcePath, string targetRootPath, string backupPassword, int retentionDays)
     {
         try
         {
             // Ensure the target directory exists
             if (!Directory.Exists(targetRootPath)) Directory.CreateDirectory(targetRootPath);
 
-            string datePart = DateTime.Now.ToString("yyyy-MM-dd");
-            string baseFileName = $"{datePart}-{userId}_Backup";
-
-            // Determine target file path based on rotation logic
-            string targetFilePath = await Task.Run(() => RotateAndGetPath(targetRootPath, baseFileName));
+            string timestamp = DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss");
+            string fileName = $"{timestamp}-{userId}_Backup.pngx";
+            string targetFilePath = Path.Combine(targetRootPath, fileName);
             string tempZipPath = targetFilePath + ".tmp";
 
             await Task.Run(() =>
             {
                 if (File.Exists(tempZipPath)) File.Delete(tempZipPath);
-                if (File.Exists(targetFilePath)) File.Delete(targetFilePath);
-
                 ZipFile.CreateFromDirectory(sourcePath, tempZipPath);
             });
 
             await EncryptFileAsync(tempZipPath, targetFilePath, backupPassword);
 
-            File.Delete(tempZipPath);
+            if (File.Exists(tempZipPath)) File.Delete(tempZipPath);
+            _logger.LogInformation("Backup created: {Path}", targetFilePath);
 
-            _logger.LogInformation("Encrypted backup created for {User} at {Path}", userId, targetFilePath);
-
-            // Remove older backups from previous days
-            await CleanUpOldBackupsAsync(targetRootPath, userId);
+            await CleanUpOldBackupsAsync(targetRootPath, userId, retentionDays);
         }
         catch (DirectoryNotFoundException)
         {
-            _logger.LogWarning("Source directory for user {User} not found: {Path}", userId, sourcePath);
+            _logger.LogWarning("Source directory not found for user {User}", userId);
         }
         catch (Exception ex)
         {
@@ -64,10 +59,7 @@ public class BackupManager(ILogger<BackupManager> logger) : IBackupManager
     {
         // 1. Generate random Salt (16 bytes)
         byte[] salt = new byte[16];
-        using (var rng = RandomNumberGenerator.Create())
-        {
-            rng.GetBytes(salt);
-        }
+        using (var rng = RandomNumberGenerator.Create()) { rng.GetBytes(salt); }
 
         // 2. Derive Key and IV from Password and Salt
         using var kdf = new Rfc2898DeriveBytes(password, salt, 50000, HashAlgorithmName.SHA256);
@@ -94,71 +86,57 @@ public class BackupManager(ILogger<BackupManager> logger) : IBackupManager
         await fsInput.CopyToAsync(cs);
     }
 
-    // Rotates files to keep max 3 versions per day (Base -> 1 -> 2)
-    private static string RotateAndGetPath(string folder, string baseName)
+    public Task CleanUpOldBackupsAsync(string targetPath, string userName)
     {
-        string file0 = Path.Combine(folder, $"{baseName}.pngx");
-        string file1 = Path.Combine(folder, $"{baseName}1.pngx");
-        string file2 = Path.Combine(folder, $"{baseName}2.pngx");
-
-        // Shift existing files: 1->2, 0->1
-        if (File.Exists(file1))
-        {
-            if (File.Exists(file2)) File.Delete(file2);
-            File.Move(file1, file2);
-        }
-
-        if (File.Exists(file0))
-        {
-            File.Move(file0, file1);
-        }
-
-        return file0;
+        return CleanUpOldBackupsAsync(targetPath, userName, 7);
     }
 
-    // Deletes files from previous days, keeping only the latest one per day
-    public Task CleanUpOldBackupsAsync(string targetPath, string userName)
+    public Task CleanUpOldBackupsAsync(string targetPath, string userName, int retentionDays)
     {
         return Task.Run(() =>
         {
             try
             {
+                if (retentionDays <= 0)
+                {
+                    _logger.LogDebug("Retention policy disabled (days <= 0). Keeping all files.");
+                    return;
+                }
+
                 DirectoryInfo dir = new(targetPath);
                 if (!dir.Exists) return;
 
-                string todayString = DateTime.Now.ToString("yyyy-MM-dd");
+                var files = dir.GetFiles($"*-{userName}_Backup.pngx");
+                DateTime now = DateTime.Now;
 
-                // Find all backup files for this user
-                var files = dir.GetFiles($"*-{userName}_Backup*.pngx");
-
-                // Group by Date part of filename
-                var groups = files.GroupBy(f => f.Name.Length >= 10 ? f.Name[..10] : "unknown");
-
-                foreach (var group in groups)
+                foreach (var file in files)
                 {
-                    // Skip today's backups
-                    if (group.Key == todayString) continue;
-
-                    // Keep only the newest file in the group
-                    var orderedFiles = group.OrderByDescending(f => f.LastWriteTime).ToList();
-
-                    for (int i = 1; i < orderedFiles.Count; i++)
+                    if (file.Name.Length >= 19)
                     {
-                        try
+                        string datePart = file.Name[..19];
+                        if (DateTime.TryParseExact(datePart, "yyyy-MM-dd_HH-mm-ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime backupDate))
                         {
-                            orderedFiles[i].Delete();
-                            _logger.LogDebug("Deleted old backup: {Name}", orderedFiles[i].Name);
-                        }
-                        catch (Exception delEx)
-                        {
-                            _logger.LogWarning(delEx, "Failed to delete file {Name}", orderedFiles[i].Name);
+                            double ageInDays = (now - backupDate).TotalDays;
+
+                            if (ageInDays > retentionDays)
+                            {
+                                try
+                                {
+                                    file.Delete();
+                                    _logger.LogDebug("Deleted expired backup: {Name} (Age: {Age:F1} days)", file.Name, ageInDays);
+                                }
+                                catch (Exception delEx)
+                                {
+                                    _logger.LogWarning(delEx, "Failed to delete old backup {Name}", file.Name);
+                                }
+                            }
                         }
                     }
                 }
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error during old backup cleanup");
+                _logger.LogError(ex, "Error during retention cleanup");
             }
         });
     }

--- a/src/Infrastructure/Pango.Infrastructure/Services/BackupManager.cs
+++ b/src/Infrastructure/Pango.Infrastructure/Services/BackupManager.cs
@@ -1,24 +1,23 @@
 ﻿using Microsoft.Extensions.Logging;
-using Pango.Application.Common;
 using Pango.Application.Common.Interfaces.Services;
 using System.Globalization;
 using System.IO.Compression;
 using System.Security.Cryptography;
+using System.Text;
 
 namespace Pango.Infrastructure.Services;
 
 public class BackupManager(ILogger<BackupManager> logger) : IBackupManager
 {
+    private const int DefaultRetentionDays = 7;
+    private const int TimestampPrefixLength = 19;
+    private const string DateFormat = "yyyy-MM-dd_HH-mm-ss";
+
     private readonly ILogger<BackupManager> _logger = logger;
 
-    // Legacy method required by interface, currently unused
-    public async Task PerformBackupAsync(BackupSettings settings)
-    {
-        if (string.IsNullOrEmpty(settings.TargetFolderPath)) return;
-        await Task.CompletedTask;
-    }
-
-    // Main logic: Rotates files, Zips content, Encrypts Zip, and Cleans up old files
+    /// <summary>
+    /// Orchestrates the backup process: zips, encrypts, and rotates old files.
+    /// </summary>
     public async Task PerformBackupForUserAsync(string userId, string sourcePath, string targetRootPath, string backupPassword, int retentionDays)
     {
         try
@@ -26,27 +25,27 @@ public class BackupManager(ILogger<BackupManager> logger) : IBackupManager
             // Ensure the target directory exists
             if (!Directory.Exists(targetRootPath)) Directory.CreateDirectory(targetRootPath);
 
-            string timestamp = DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss");
-            string fileName = $"{timestamp}-{userId}_Backup.pngx";
+            string fileName = GenerateBackupFileName(userId);
             string targetFilePath = Path.Combine(targetRootPath, fileName);
             string tempZipPath = targetFilePath + ".tmp";
 
-            await Task.Run(() =>
-            {
-                if (File.Exists(tempZipPath)) File.Delete(tempZipPath);
-                ZipFile.CreateFromDirectory(sourcePath, tempZipPath);
-            });
+            if (File.Exists(tempZipPath)) File.Delete(tempZipPath);
+            ZipFile.CreateFromDirectory(sourcePath, tempZipPath);
 
             await EncryptFileAsync(tempZipPath, targetFilePath, backupPassword);
 
             if (File.Exists(tempZipPath)) File.Delete(tempZipPath);
-            _logger.LogInformation("Backup created: {Path}", targetFilePath);
+
+            if (_logger.IsEnabled(LogLevel.Information))
+            {
+                _logger.LogInformation("Backup created: {Path}", targetFilePath);
+            }
 
             await CleanUpOldBackupsAsync(targetRootPath, userId, retentionDays);
         }
-        catch (DirectoryNotFoundException)
+        catch (DirectoryNotFoundException ex)
         {
-            _logger.LogWarning("Source directory not found for user {User}", userId);
+            _logger.LogError(ex, "Source directory not found for user {User}", userId);
         }
         catch (Exception ex)
         {
@@ -54,7 +53,18 @@ public class BackupManager(ILogger<BackupManager> logger) : IBackupManager
         }
     }
 
-    // Encrypts file using AES-256 with a random Salt and IV stored in the file header
+    /// <summary>
+    /// Generates a unique filename based on current timestamp and user ID.
+    /// </summary>
+    private static string GenerateBackupFileName(string userId)
+    {
+        string timestamp = DateTime.Now.ToString(DateFormat);
+        return $"{timestamp}-{userId}_Backup.pngx";
+    }
+
+    /// <summary>
+    /// Encrypts a file using AES-256 with Pbkdf2 key derivation.
+    /// </summary>
     private static async Task EncryptFileAsync(string inputFile, string outputFile, string password)
     {
         // 1. Generate random Salt (16 bytes)
@@ -62,13 +72,11 @@ public class BackupManager(ILogger<BackupManager> logger) : IBackupManager
         using (var rng = RandomNumberGenerator.Create()) { rng.GetBytes(salt); }
 
         // 2. Derive Key and IV from Password and Salt
-        using var kdf = new Rfc2898DeriveBytes(password, salt, 50000, HashAlgorithmName.SHA256);
-        byte[] key = kdf.GetBytes(32);
-        byte[] iv = kdf.GetBytes(16);
+        byte[] derivedBytes = Rfc2898DeriveBytes.Pbkdf2(Encoding.UTF8.GetBytes(password), salt, 50000, HashAlgorithmName.SHA256, 48);
 
         using var aes = Aes.Create();
-        aes.Key = key;
-        aes.IV = iv;
+        aes.Key = derivedBytes[0..32];
+        aes.IV = derivedBytes[32..48];
         aes.Mode = CipherMode.CBC;
         aes.Padding = PaddingMode.PKCS7;
 
@@ -78,7 +86,7 @@ public class BackupManager(ILogger<BackupManager> logger) : IBackupManager
         await fsOutput.WriteAsync(salt.AsMemory(0, salt.Length));
 
         // 4. Write IV (16 bytes) to the file
-        await fsOutput.WriteAsync(iv.AsMemory(0, iv.Length));
+        await fsOutput.WriteAsync(aes.IV.AsMemory(0, aes.IV.Length));
 
         // 5. Write Encrypted Data
         await using var cs = new CryptoStream(fsOutput, aes.CreateEncryptor(), CryptoStreamMode.Write);
@@ -86,58 +94,66 @@ public class BackupManager(ILogger<BackupManager> logger) : IBackupManager
         await fsInput.CopyToAsync(cs);
     }
 
+    /// <summary>
+    /// Overload for cleanup using the default retention period.
+    /// </summary>
     public Task CleanUpOldBackupsAsync(string targetPath, string userName)
     {
-        return CleanUpOldBackupsAsync(targetPath, userName, 7);
+        return CleanUpOldBackupsAsync(targetPath, userName, DefaultRetentionDays);
     }
 
+    /// <summary>
+    /// Deletes backup files older than the specified retention days.
+    /// </summary>
     public Task CleanUpOldBackupsAsync(string targetPath, string userName, int retentionDays)
     {
-        return Task.Run(() =>
+        try
         {
-            try
+            if (retentionDays <= 0)
             {
-                if (retentionDays <= 0)
+                _logger.LogDebug("Retention policy disabled. Keeping all files.");
+                return Task.CompletedTask;
+            }
+
+            DirectoryInfo dir = new(targetPath);
+            if (!dir.Exists) return Task.CompletedTask;
+
+            var files = dir.GetFiles($"*-{userName}_Backup.pngx");
+            DateTime now = DateTime.Now;
+
+            foreach (var file in files)
+            {
+                if (file.Name.Length >= TimestampPrefixLength)
                 {
-                    _logger.LogDebug("Retention policy disabled (days <= 0). Keeping all files.");
-                    return;
-                }
-
-                DirectoryInfo dir = new(targetPath);
-                if (!dir.Exists) return;
-
-                var files = dir.GetFiles($"*-{userName}_Backup.pngx");
-                DateTime now = DateTime.Now;
-
-                foreach (var file in files)
-                {
-                    if (file.Name.Length >= 19)
+                    string datePart = file.Name[..TimestampPrefixLength];
+                    if (DateTime.TryParseExact(datePart, DateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime backupDate))
                     {
-                        string datePart = file.Name[..19];
-                        if (DateTime.TryParseExact(datePart, "yyyy-MM-dd_HH-mm-ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime backupDate))
-                        {
-                            double ageInDays = (now - backupDate).TotalDays;
+                        double ageInDays = (now - backupDate).TotalDays;
 
-                            if (ageInDays > retentionDays)
+                        if (ageInDays > retentionDays)
+                        {
+                            try
                             {
-                                try
+                                file.Delete();
+                                if (_logger.IsEnabled(LogLevel.Debug))
                                 {
-                                    file.Delete();
                                     _logger.LogDebug("Deleted expired backup: {Name} (Age: {Age:F1} days)", file.Name, ageInDays);
                                 }
-                                catch (Exception delEx)
-                                {
-                                    _logger.LogWarning(delEx, "Failed to delete old backup {Name}", file.Name);
-                                }
+                            }
+                            catch (Exception delEx)
+                            {
+                                _logger.LogWarning(delEx, "Failed to delete old backup {Name}", file.Name);
                             }
                         }
                     }
                 }
             }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error during retention cleanup");
-            }
-        });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during retention cleanup");
+        }
+
+        return Task.CompletedTask;
     }
 }

--- a/src/Infrastructure/Pango.Infrastructure/Services/BackupManager.cs
+++ b/src/Infrastructure/Pango.Infrastructure/Services/BackupManager.cs
@@ -1,0 +1,165 @@
+﻿using Microsoft.Extensions.Logging;
+using Pango.Application.Common;
+using Pango.Application.Common.Interfaces.Services;
+using System.IO.Compression;
+using System.Security.Cryptography;
+
+namespace Pango.Infrastructure.Services;
+
+public class BackupManager(ILogger<BackupManager> logger) : IBackupManager
+{
+    private readonly ILogger<BackupManager> _logger = logger;
+
+    // Legacy method required by interface, currently unused
+    public async Task PerformBackupAsync(BackupSettings settings)
+    {
+        if (string.IsNullOrEmpty(settings.TargetFolderPath)) return;
+        await Task.CompletedTask;
+    }
+
+    // Main logic: Rotates files, Zips content, Encrypts Zip, and Cleans up old files
+    public async Task PerformBackupForUserAsync(string userId, string sourcePath, string targetRootPath, string backupPassword)
+    {
+        try
+        {
+            // Ensure the target directory exists
+            if (!Directory.Exists(targetRootPath)) Directory.CreateDirectory(targetRootPath);
+
+            string datePart = DateTime.Now.ToString("yyyy-MM-dd");
+            string baseFileName = $"{datePart}-{userId}_Backup";
+
+            // Determine target file path based on rotation logic
+            string targetFilePath = await Task.Run(() => RotateAndGetPath(targetRootPath, baseFileName));
+            string tempZipPath = targetFilePath + ".tmp";
+
+            await Task.Run(() =>
+            {
+                if (File.Exists(tempZipPath)) File.Delete(tempZipPath);
+                if (File.Exists(targetFilePath)) File.Delete(targetFilePath);
+
+                ZipFile.CreateFromDirectory(sourcePath, tempZipPath);
+            });
+
+            await EncryptFileAsync(tempZipPath, targetFilePath, backupPassword);
+
+            File.Delete(tempZipPath);
+
+            _logger.LogInformation("Encrypted backup created for {User} at {Path}", userId, targetFilePath);
+
+            // Remove older backups from previous days
+            await CleanUpOldBackupsAsync(targetRootPath, userId);
+        }
+        catch (DirectoryNotFoundException)
+        {
+            _logger.LogWarning("Source directory for user {User} not found: {Path}", userId, sourcePath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Backup failed for user {User}", userId);
+        }
+    }
+
+    // Encrypts file using AES-256 with a random Salt and IV stored in the file header
+    private static async Task EncryptFileAsync(string inputFile, string outputFile, string password)
+    {
+        // 1. Generate random Salt (16 bytes)
+        byte[] salt = new byte[16];
+        using (var rng = RandomNumberGenerator.Create())
+        {
+            rng.GetBytes(salt);
+        }
+
+        // 2. Derive Key and IV from Password and Salt
+        using var kdf = new Rfc2898DeriveBytes(password, salt, 50000, HashAlgorithmName.SHA256);
+        byte[] key = kdf.GetBytes(32);
+        byte[] iv = kdf.GetBytes(16);
+
+        using var aes = Aes.Create();
+        aes.Key = key;
+        aes.IV = iv;
+        aes.Mode = CipherMode.CBC;
+        aes.Padding = PaddingMode.PKCS7;
+
+        await using var fsOutput = new FileStream(outputFile, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true);
+
+        // 3. Write Salt (16 bytes) to the beginning of the file
+        await fsOutput.WriteAsync(salt.AsMemory(0, salt.Length));
+
+        // 4. Write IV (16 bytes) to the file
+        await fsOutput.WriteAsync(iv.AsMemory(0, iv.Length));
+
+        // 5. Write Encrypted Data
+        await using var cs = new CryptoStream(fsOutput, aes.CreateEncryptor(), CryptoStreamMode.Write);
+        await using var fsInput = new FileStream(inputFile, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true);
+        await fsInput.CopyToAsync(cs);
+    }
+
+    // Rotates files to keep max 3 versions per day (Base -> 1 -> 2)
+    private static string RotateAndGetPath(string folder, string baseName)
+    {
+        string file0 = Path.Combine(folder, $"{baseName}.pngx");
+        string file1 = Path.Combine(folder, $"{baseName}1.pngx");
+        string file2 = Path.Combine(folder, $"{baseName}2.pngx");
+
+        // Shift existing files: 1->2, 0->1
+        if (File.Exists(file1))
+        {
+            if (File.Exists(file2)) File.Delete(file2);
+            File.Move(file1, file2);
+        }
+
+        if (File.Exists(file0))
+        {
+            File.Move(file0, file1);
+        }
+
+        return file0;
+    }
+
+    // Deletes files from previous days, keeping only the latest one per day
+    public Task CleanUpOldBackupsAsync(string targetPath, string userName)
+    {
+        return Task.Run(() =>
+        {
+            try
+            {
+                DirectoryInfo dir = new(targetPath);
+                if (!dir.Exists) return;
+
+                string todayString = DateTime.Now.ToString("yyyy-MM-dd");
+
+                // Find all backup files for this user
+                var files = dir.GetFiles($"*-{userName}_Backup*.pngx");
+
+                // Group by Date part of filename
+                var groups = files.GroupBy(f => f.Name.Length >= 10 ? f.Name[..10] : "unknown");
+
+                foreach (var group in groups)
+                {
+                    // Skip today's backups
+                    if (group.Key == todayString) continue;
+
+                    // Keep only the newest file in the group
+                    var orderedFiles = group.OrderByDescending(f => f.LastWriteTime).ToList();
+
+                    for (int i = 1; i < orderedFiles.Count; i++)
+                    {
+                        try
+                        {
+                            orderedFiles[i].Delete();
+                            _logger.LogDebug("Deleted old backup: {Name}", orderedFiles[i].Name);
+                        }
+                        catch (Exception delEx)
+                        {
+                            _logger.LogWarning(delEx, "Failed to delete file {Name}", orderedFiles[i].Name);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during old backup cleanup");
+            }
+        });
+    }
+}

--- a/src/Infrastructure/Pango.Infrastructure/Services/ContentEncoder.cs
+++ b/src/Infrastructure/Pango.Infrastructure/Services/ContentEncoder.cs
@@ -10,98 +10,118 @@ namespace Pango.Infrastructure.Services;
 
 public class ContentEncoder : IContentEncoder
 {
-    public Task<T?> DecryptAsync<T>(byte[] encryptedContent, string key, string salt)
+    /// <summary>
+    /// Decrypts a byte array into an object of type T using the provided key and salt.
+    /// </summary>
+    /// <param name="encryptedContent">The raw encrypted bytes.</param>
+    /// <param name="key">The Base64 encoded encryption key.</param>
+    /// <param name="salt">The Base64 encoded initialization vector (IV).</param>
+    public async Task<T?> DecryptAsync<T>(byte[] encryptedContent, string key, string salt)
     {
-        try
+        return await Task.Run(() =>
         {
-            if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(salt))
-                throw new ArgumentException("Key and Salt cannot be empty");
-
-            byte[] keyBytes;
-            byte[] ivBytes;
-
             try
             {
-                keyBytes = Convert.FromBase64String(key);
-                ivBytes = Convert.FromBase64String(salt);
-            }
-            catch (FormatException ex)
-            {
-                throw new PangoDataDecryptionException(ApplicationErrors.Data.DecryptionError, "Invalid key format (Base64 expected).", ex);
-            }
+                if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(salt))
+                    throw new ArgumentException("Key and Salt cannot be empty");
 
-            string jsonContent = Decrypt(encryptedContent, keyBytes, ivBytes);
+                byte[] keyBytes;
+                byte[] ivBytes;
 
-            var deserializedObject = JsonConvert.DeserializeObject<T>(jsonContent);
-
-            // DS
-            // this code converts JArray into a List<object>
-            if (deserializedObject is IHaveEncodedData encodedData && encodedData.Data != null)
-            {
-                var encodedDataType = encodedData.Data.GetType();
-                if (encodedDataType == typeof(JArray))
+                try
                 {
-                    var dataType = Type.GetType(encodedData.DataType ?? string.Empty);
-                    if (dataType != null)
+                    keyBytes = Convert.FromBase64String(key);
+                    ivBytes = Convert.FromBase64String(salt);
+                }
+                catch (FormatException ex)
+                {
+                    throw new PangoDataDecryptionException(ApplicationErrors.Data.DecryptionError, "Invalid key format (Base64 expected).", ex);
+                }
+
+                string jsonContent = Decrypt(encryptedContent, keyBytes, ivBytes);
+
+                var deserializedObject = JsonConvert.DeserializeObject<T>(jsonContent);
+
+                // DS
+                // this code converts JArray into a List<object>
+                if (deserializedObject is IHaveEncodedData encodedData && encodedData.Data != null)
+                {
+                    var encodedDataType = encodedData.Data.GetType();
+                    if (encodedDataType == typeof(JArray))
                     {
-                        encodedData.Data = ((JArray)encodedData.Data).ToObject(dataType);
+                        var dataType = Type.GetType(encodedData.DataType ?? string.Empty);
+                        if (dataType != null)
+                        {
+                            encodedData.Data = ((JArray)encodedData.Data).ToObject(dataType);
+                        }
                     }
                 }
+
+                return deserializedObject;
             }
-
-            return Task.FromResult(deserializedObject);
-        }
-        catch (PangoDataDecryptionException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            throw new PangoDataDecryptionException(
-                ApplicationErrors.Data.DecryptionError,
-                $"Decryption failed for {typeof(T).Name}.",
-                ex);
-        }
+            catch (PangoDataDecryptionException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new PangoDataDecryptionException(
+                    ApplicationErrors.Data.DecryptionError,
+                    $"Decryption failed for {typeof(T).Name}.",
+                    ex);
+            }
+        });
     }
 
-    public Task<byte[]> EncryptAsync<T>(T content, string key, string salt)
+    /// <summary>
+    /// Encrypts an object of type T into a byte array using the provided key and salt.
+    /// </summary>
+    /// <param name="content">The object to be encrypted.</param>
+    /// <param name="key">The Base64 encoded encryption key.</param>
+    /// <param name="salt">The Base64 encoded initialization vector (IV).</param>
+    public async Task<byte[]> EncryptAsync<T>(T content, string key, string salt)
     {
-        try
+        return await Task.Run(() =>
         {
-            string json = JsonConvert.SerializeObject(content, new JsonSerializerSettings() { ReferenceLoopHandling = ReferenceLoopHandling.Ignore });
+            try
+            {
+                string json = JsonConvert.SerializeObject(content, new JsonSerializerSettings() { ReferenceLoopHandling = ReferenceLoopHandling.Ignore });
 
-            byte[] result = Encrypt(json, Convert.FromBase64String(key), Convert.FromBase64String(salt));
-            return Task.FromResult(result);
-        }
-        catch (Exception ex)
-        {
-            throw new PangoDataEncryptionException(ApplicationErrors.Data.EncryptionError, $"Cannot encrypt data of type {typeof(T).Name}", ex);
-        }
+                return Encrypt(json, Convert.FromBase64String(key), Convert.FromBase64String(salt));
+            }
+            catch (Exception ex)
+            {
+                throw new PangoDataEncryptionException(ApplicationErrors.Data.EncryptionError, $"Cannot encrypt data of type {typeof(T).Name}", ex);
+            }
+        });
     }
 
+    /// <summary>
+    /// Internal helper to execute AES encryption logic.
+    /// </summary>
     private static byte[] Encrypt(string simpletext, byte[] key, byte[] iv)
     {
         Ensure.AreEqual(key.Length, 32, nameof(key));
         Ensure.AreEqual(iv.Length, 16, nameof(key));
 
-        byte[] cipheredtext;
-        using (Aes aes = Aes.Create())
+        using Aes aes = Aes.Create();
+        aes.Padding = PaddingMode.PKCS7;
+        aes.Mode = CipherMode.CBC;
+
+        using ICryptoTransform encryptor = aes.CreateEncryptor(key, iv);
+        using MemoryStream memoryStream = new();
+        using (CryptoStream cryptoStream = new(memoryStream, encryptor, CryptoStreamMode.Write))
+        using (StreamWriter streamWriter = new(cryptoStream))
         {
-            aes.Padding = PaddingMode.PKCS7;
-
-            ICryptoTransform encryptor = aes.CreateEncryptor(key, iv);
-            using MemoryStream memoryStream = new();
-            using CryptoStream cryptoStream = new(memoryStream, encryptor, CryptoStreamMode.Write);
-            using (StreamWriter streamWriter = new(cryptoStream))
-            {
-                streamWriter.Write(simpletext);
-            }
-
-            cipheredtext = memoryStream.ToArray();
+            streamWriter.Write(simpletext);
         }
-        return cipheredtext;
+
+        return memoryStream.ToArray();
     }
 
+    /// <summary>
+    /// Internal helper to execute AES decryption logic.
+    /// </summary>
     private static string Decrypt(byte[] cipheredText, byte[] key, byte[] iv)
     {
         Ensure.AreEqual(key.Length, 32, nameof(key));

--- a/src/Infrastructure/Pango.Infrastructure/Services/ContentEncoder.cs
+++ b/src/Infrastructure/Pango.Infrastructure/Services/ContentEncoder.cs
@@ -10,46 +10,68 @@ namespace Pango.Infrastructure.Services;
 
 public class ContentEncoder : IContentEncoder
 {
-    public async Task<T?> DecryptAsync<T>(byte[] encryptedContent, string key, string salt)
+    public Task<T?> DecryptAsync<T>(byte[] encryptedContent, string key, string salt)
     {
         try
         {
-            string jsonContent = await Task.Run(() => Decrypt(encryptedContent, Convert.FromBase64String(key), Convert.FromBase64String(salt)));
+            if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(salt))
+                throw new ArgumentException("Key and Salt cannot be empty");
+
+            byte[] keyBytes;
+            byte[] ivBytes;
+
+            try
+            {
+                keyBytes = Convert.FromBase64String(key);
+                ivBytes = Convert.FromBase64String(salt);
+            }
+            catch (FormatException ex)
+            {
+                throw new PangoDataDecryptionException(ApplicationErrors.Data.DecryptionError, "Invalid key format (Base64 expected).", ex);
+            }
+
+            string jsonContent = Decrypt(encryptedContent, keyBytes, ivBytes);
 
             var deserializedObject = JsonConvert.DeserializeObject<T>(jsonContent);
 
             // DS
             // this code converts JArray into a List<object>
-            if(deserializedObject is IHaveEncodedData encodedData && encodedData.Data != null)
+            if (deserializedObject is IHaveEncodedData encodedData && encodedData.Data != null)
             {
                 var encodedDataType = encodedData.Data.GetType();
-
                 if (encodedDataType == typeof(JArray))
                 {
                     var dataType = Type.GetType(encodedData.DataType ?? string.Empty);
-
-                    if(dataType != null)
+                    if (dataType != null)
                     {
                         encodedData.Data = ((JArray)encodedData.Data).ToObject(dataType);
                     }
                 }
             }
 
-            return deserializedObject;
+            return Task.FromResult(deserializedObject);
         }
-        catch(Exception ex)
+        catch (PangoDataDecryptionException)
         {
-            throw new PangoDataEncryptionException(ApplicationErrors.Data.EncryptionError, $"Cannot decrypt data of type {typeof(T).Name}", ex);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new PangoDataDecryptionException(
+                ApplicationErrors.Data.DecryptionError,
+                $"Decryption failed for {typeof(T).Name}.",
+                ex);
         }
     }
 
-    public async Task<byte[]> EncryptAsync<T>(T content, string key, string salt)
+    public Task<byte[]> EncryptAsync<T>(T content, string key, string salt)
     {
         try
         {
             string json = JsonConvert.SerializeObject(content, new JsonSerializerSettings() { ReferenceLoopHandling = ReferenceLoopHandling.Ignore });
 
-            return await Task.Run(() => Encrypt(json, Convert.FromBase64String(key), Convert.FromBase64String(salt)));
+            byte[] result = Encrypt(json, Convert.FromBase64String(key), Convert.FromBase64String(salt));
+            return Task.FromResult(result);
         }
         catch (Exception ex)
         {
@@ -68,18 +90,14 @@ public class ContentEncoder : IContentEncoder
             aes.Padding = PaddingMode.PKCS7;
 
             ICryptoTransform encryptor = aes.CreateEncryptor(key, iv);
-            using (MemoryStream memoryStream = new())
+            using MemoryStream memoryStream = new();
+            using CryptoStream cryptoStream = new(memoryStream, encryptor, CryptoStreamMode.Write);
+            using (StreamWriter streamWriter = new(cryptoStream))
             {
-                using (CryptoStream cryptoStream = new(memoryStream, encryptor, CryptoStreamMode.Write))
-                {
-                    using (StreamWriter streamWriter = new(cryptoStream))
-                    {
-                        streamWriter.Write(simpletext);
-                    }
-
-                    cipheredtext = memoryStream.ToArray();
-                }
+                streamWriter.Write(simpletext);
             }
+
+            cipheredtext = memoryStream.ToArray();
         }
         return cipheredtext;
     }
@@ -87,25 +105,26 @@ public class ContentEncoder : IContentEncoder
     private static string Decrypt(byte[] cipheredText, byte[] key, byte[] iv)
     {
         Ensure.AreEqual(key.Length, 32, nameof(key));
-        Ensure.AreEqual(iv.Length, 16, nameof(key));
+        Ensure.AreEqual(iv.Length, 16, nameof(iv));
 
-        string simpletext = String.Empty;
         try
         {
             using Aes aes = Aes.Create();
+            aes.Key = key;
+            aes.IV = iv;
             aes.Padding = PaddingMode.PKCS7;
+            aes.Mode = CipherMode.CBC;
 
-            ICryptoTransform decryptor = aes.CreateDecryptor(key, iv);
+            using ICryptoTransform decryptor = aes.CreateDecryptor();
             using MemoryStream memoryStream = new(cipheredText);
             using CryptoStream cryptoStream = new(memoryStream, decryptor, CryptoStreamMode.Read);
             using StreamReader streamReader = new(cryptoStream);
-            simpletext = streamReader.ReadToEnd();
+
+            return streamReader.ReadToEnd();
         }
-        catch(Exception ex)
+        catch (CryptographicException ex)
         {
             throw new PangoDataDecryptionException(ApplicationErrors.Data.DecryptionError, "Data decryption failed: probably the key is wrong", ex);
         }
-
-        return simpletext;
     }
 }

--- a/src/Infrastructure/Pango.Persistence.File/Pango.Persistence.File.csproj
+++ b/src/Infrastructure/Pango.Persistence.File/Pango.Persistence.File.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.Packaging" Version="8.0.0" />
+    <PackageReference Include="System.IO.Packaging" Version="10.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Infrastructure/Pango.Persistence.File/PangoFileDataExporter.cs
+++ b/src/Infrastructure/Pango.Persistence.File/PangoFileDataExporter.cs
@@ -8,23 +8,16 @@ using Package = System.IO.Packaging.Package;
 
 namespace Pango.Persistence.File;
 
-public class PangoFileDataExporter : IDataExporter
+public class PangoFileDataExporter(IContentEncoder contentEncoder, IAppDomainProvider appDomainProvider, ILogger<PangoFileDataExporter> logger) : IDataExporter
 {
-    private readonly IContentEncoder _contentEncoder;
-    private readonly IAppDomainProvider _appDomainProvider;
-    private readonly ILogger _logger;
+    private readonly IContentEncoder _contentEncoder = contentEncoder;
+    private readonly IAppDomainProvider _appDomainProvider = appDomainProvider;
+    private readonly ILogger _logger = logger;
 
     private static readonly SemaphoreSlim _semaphore = new(1, 1);
     private const string PackageFileExtension = ".pngx";
     private const int MaxRetries = 3;
     private const int DelayMiliseconds = 1000;
-
-    public PangoFileDataExporter(IContentEncoder contentEncoder, IAppDomainProvider appDomainProvider, ILogger<PangoFileDataExporter> logger)
-    {
-        _contentEncoder = contentEncoder;
-        _appDomainProvider = appDomainProvider;
-        _logger = logger;
-    }
 
     public async Task<string> ExportAsync(PangoPackageManifest manifest, IEnumerable<IContentPackage> contentPackages, IExportOptions exportOptions)
     {
@@ -49,7 +42,7 @@ public class PangoFileDataExporter : IDataExporter
                     byte[] encryptedManifestData = await _contentEncoder.EncryptAsync(manifest, exportOptions.EncodingOptions.Key, exportOptions.EncodingOptions.Salt);
                     using (Stream partStream = manifestPart.GetStream())
                     {
-                        partStream.Write(encryptedManifestData, 0, encryptedManifestData.Length);
+                        await partStream.WriteAsync(encryptedManifestData);
                     }
 
                     int partIndex = 1;
@@ -65,7 +58,7 @@ public class PangoFileDataExporter : IDataExporter
                         // Write the encrypted data to the package part
                         using (Stream partStream = part.GetStream())
                         {
-                            partStream.Write(encryptedData, 0, encryptedData.Length);
+                            await partStream.WriteAsync(encryptedData);
                         }
 
                         partIndex++;

--- a/src/Infrastructure/Pango.Persistence.File/PangoFileDataImporter.cs
+++ b/src/Infrastructure/Pango.Persistence.File/PangoFileDataImporter.cs
@@ -4,27 +4,27 @@ using Pango.Application.Common.Exceptions;
 using Pango.Application.Common.Interfaces.Persistence;
 using Pango.Application.Common.Interfaces.Services;
 using Pango.Application.Models;
-using System.IO.Packaging;
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace Pango.Persistence.File;
 
-public class PangoFileDataImporter : IDataImporter
+public class PangoFileDataImporter(
+    IContentEncoder contentEncoder,
+    IAppDomainProvider appDomainProvider,
+    IUserContextProvider userContextProvider,
+    ILogger<PangoFileDataImporter> logger) : IDataImporter
 {
-    private readonly IContentEncoder _contentEncoder;
-    private readonly IAppDomainProvider _appDomainProvider;
-    private readonly ILogger _logger;
+    private readonly IContentEncoder _contentEncoder = contentEncoder;
+    private readonly IAppDomainProvider _appDomainProvider = appDomainProvider;
+    private readonly IUserContextProvider _userContextProvider = userContextProvider;
+    private readonly ILogger _logger = logger;
 
     private static readonly SemaphoreSlim _semaphore = new (1, 1);
     private const int MaxRetries = 3;
     private const int DelayMiliseconds = 1000;
     private const string PackageFileExtension = ".pngx";
-
-    public PangoFileDataImporter(IContentEncoder contentEncoder, IAppDomainProvider appDomainProvider, ILogger<PangoFileDataImporter> logger)
-    {
-        _contentEncoder = contentEncoder;
-        _appDomainProvider = appDomainProvider;
-        _logger = logger;
-    }
 
     public async Task<ImportResultDto> ImportAsync(string filePath, IImportOptions importOptions)
     {
@@ -33,72 +33,225 @@ public class PangoFileDataImporter : IDataImporter
 
         await _semaphore.WaitAsync();
 
-        ThrowIfFileIsNotValid(filePath);
+        string tempDecryptedPath = string.Empty;
 
         try
         {
+            ThrowIfFileIsNotValid(filePath);
+
+            // 1. Detect if the file is a standard Zip (Export) or Encrypted (Backup)
+            bool isEncryptedBackup = false;
+            try
+            {
+                using (ZipFile.OpenRead(filePath)) { }
+            }
+            catch (InvalidDataException)
+            {
+                isEncryptedBackup = true;
+            }
+            catch (Exception)
+            {
+                isEncryptedBackup = true;
+            }
+
+            string workingFilePath = filePath;
+
+            // 2. Decrypt Backup Container (if applicable)
+            if (isEncryptedBackup)
+            {
+                _logger.LogInformation("File appears encrypted. Attempting backup decryption...");
+                tempDecryptedPath = Path.GetTempFileName();
+
+                string backupPassword = importOptions.EncodingOptions.Key;
+
+                try
+                {
+                    await DecryptBackupFileAsync(filePath, tempDecryptedPath, backupPassword);
+                    workingFilePath = tempDecryptedPath;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Backup decryption failed.");
+                    throw new PangoDataDecryptionException(ApplicationErrors.Data.DecryptionError, "Invalid backup password.", ex);
+                }
+            }
+
+            // Get User Keys
+            EncodingOptions userOptions = await _userContextProvider.GetEncodingOptionsAsync();
+
+            // 3. Process the Archive
             for (int attempt = 0; attempt < MaxRetries; attempt++)
             {
                 try
                 {
-                    _logger.LogDebug("Importing data from {filePath}", filePath);
+                    _logger.LogDebug("Reading archive from {filePath}", workingFilePath);
 
-                    // Open the package
-                    using Package package = Package.Open(filePath, FileMode.Open, FileAccess.Read);
-                    foreach (PackagePart part in package.GetParts())
+                    using var fs = new FileStream(workingFilePath, FileMode.Open);
+
+                    ZipArchive archive;
+                    try
                     {
-                        // Read the encrypted data from the package part
-                        using Stream partStream = part.GetStream();
-                        byte[] encryptedData = new byte[partStream.Length];
-                        partStream.Read(encryptedData, 0, encryptedData.Length);
+                        archive = new ZipArchive(fs, ZipArchiveMode.Read);
+                    }
+                    catch (InvalidDataException)
+                    {
+                        throw new PangoDataDecryptionException(ApplicationErrors.Data.DecryptionError, "Wrong password (archive is invalid).");
+                    }
 
-                        // Decrypt the data
-                        if (manifest is null)
+                    using (archive)
+                    {
+                        foreach (var entry in archive.Entries)
                         {
-                            manifest = await _contentEncoder.DecryptAsync<PangoPackageManifest>(encryptedData, importOptions.EncodingOptions.Key, importOptions.EncodingOptions.Salt);
-                            if(manifest is null)
-                            {
-                                throw new PangoImportException("Import failed: Manifest is not found");
-                            }
-                        }
-                        else
-                        {
-                            IContentPackage? data = await _contentEncoder.DecryptAsync<ContentPackage>(encryptedData, importOptions.EncodingOptions.Key, importOptions.EncodingOptions.Salt);
+                            if (entry.Name == "[Content_Types].xml" || entry.FullName.StartsWith("_rels") || string.IsNullOrEmpty(entry.Name))
+                                continue;
 
-                            if (data is null)
+                            using var entryStream = entry.Open();
+                            using var ms = new MemoryStream();
+                            await entryStream.CopyToAsync(ms);
+                            byte[] encryptedData = ms.ToArray();
+
+                            var decryptionOptions = isEncryptedBackup ? userOptions : importOptions.EncodingOptions;
+
+                            if (manifest == null)
                             {
-                                _logger.LogWarning("Got an empty package while importing data from {filePath}", filePath);
+                                manifest = await TryDecrypt<PangoPackageManifest>(encryptedData, decryptionOptions);
                             }
-                            else
+
+                            IContentPackage? data = await TryDecrypt<ContentPackage>(encryptedData, decryptionOptions);
+
+                            if (data == null && !isEncryptedBackup)
+                            {
+                                data = await TryDecrypt<ContentPackage>(encryptedData, userOptions);
+                            }
+
+                            if (data != null)
                             {
                                 importedPackages.Add(data);
                             }
                         }
                     }
-
-                    // If successful, break out of the loop
                     break;
                 }
-                catch(IOException e)
+                catch (PangoDataDecryptionException)
                 {
-                    _logger.LogError("An error occurred while importing data from {filePath}: {message}. Attempt {attempt}/{maxRetries}", filePath, e.Message, attempt + 1, MaxRetries);
-
+                    throw;
+                }
+                catch (IOException e)
+                {
+                    _logger.LogError("Import attempt {attempt} failed: {message}", attempt + 1, e.Message);
                     await Task.Delay(DelayMiliseconds);
-
-                    if(attempt == MaxRetries - 1)
-                    {
-                        throw;
-                    }
+                    if (attempt == MaxRetries - 1) throw;
                 }
             }
         }
         finally
         {
+            if (!string.IsNullOrEmpty(tempDecryptedPath) && System.IO.File.Exists(tempDecryptedPath))
+            {
+                try { System.IO.File.Delete(tempDecryptedPath); } catch { }
+            }
             _logger.LogDebug("Import completed");
             _semaphore.Release();
         }
 
-        return new ImportResultDto(manifest!.Value, importedPackages);
+        if (manifest is null && importedPackages.Count == 0)
+        {
+            throw new PangoDataDecryptionException(ApplicationErrors.Data.DecryptionError, "Wrong password or invalid file format.");
+        }
+
+        // 4. Construct Result
+        if (manifest is null)
+        {
+            if (importedPackages.Count > 0)
+            {
+                manifest = new PangoPackageManifest(
+                    _userContextProvider.GetUserName(),
+                    DateTime.UtcNow.ToString("G"),
+                    "Restored from Backup",
+                    new Dictionary<Domain.Enums.ContentType, int> { { Domain.Enums.ContentType.Passwords, importedPackages.Count } }
+                );
+            }
+            else
+            {
+                throw new PangoImportException("Import failed: No valid data found. Wrong password or wrong user account.");
+            }
+        }
+
+        var finalManifest = manifest.Value;
+        finalManifest.Contents ??= [];
+
+        if (importedPackages.Count > 0 && (!finalManifest.Contents.ContainsKey(Domain.Enums.ContentType.Passwords) || finalManifest.Contents[Domain.Enums.ContentType.Passwords] == 0))
+        {
+            finalManifest.Contents[Domain.Enums.ContentType.Passwords] = importedPackages.Count;
+        }
+
+        return new ImportResultDto(finalManifest, importedPackages);
+    }
+
+    private async Task<T?> TryDecrypt<T>(byte[] data, EncodingOptions options)
+    {
+        if (string.IsNullOrEmpty(options.Key)) return default;
+
+        string keyBase64 = options.Key;
+        string saltBase64 = options.Salt;
+
+        Span<byte> buffer = new(new byte[100]);
+        bool isValidKey = Convert.TryFromBase64String(options.Key, buffer, out int bytesWritten) && bytesWritten == 32;
+
+        if (!isValidKey)
+        {
+            byte[] staticSalt = Encoding.UTF8.GetBytes("PangoStaticExportSalt");
+            using var derive = new Rfc2898DeriveBytes(options.Key, staticSalt, 50000, HashAlgorithmName.SHA256);
+            keyBase64 = Convert.ToBase64String(derive.GetBytes(32));
+            saltBase64 = Convert.ToBase64String(derive.GetBytes(16));
+        }
+
+        try
+        {
+            return await _contentEncoder.DecryptAsync<T>(data, keyBase64, saltBase64);
+        }
+        catch (PangoDataDecryptionException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Decryption of an entry failed: {Message}", ex.Message);
+            return default;
+        }
+    }
+
+    private static async Task DecryptBackupFileAsync(string inputFile, string outputFile, string password)
+    {
+        await using var fsInput = new FileStream(inputFile, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true);
+
+        byte[] salt = new byte[16];
+        if (await fsInput.ReadAsync(salt.AsMemory(0, 16)) < 16)
+            throw new IOException("Invalid header");
+
+        byte[] iv = new byte[16];
+        if (await fsInput.ReadAsync(iv.AsMemory(0, 16)) < 16)
+            throw new IOException("Invalid header");
+
+        using var kdf = new Rfc2898DeriveBytes(password, salt, 50000, HashAlgorithmName.SHA256);
+        byte[] key = kdf.GetBytes(32);
+
+        using var aes = Aes.Create();
+        aes.Key = key;
+        aes.IV = iv;
+        aes.Padding = PaddingMode.PKCS7;
+
+        await using var fsOutput = new FileStream(outputFile, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true);
+        await using var cs = new CryptoStream(fsInput, aes.CreateDecryptor(), CryptoStreamMode.Read);
+
+        try
+        {
+            await cs.CopyToAsync(fsOutput);
+        }
+        catch (CryptographicException ex)
+        {
+            throw new PangoDataDecryptionException(ApplicationErrors.Data.DecryptionError, "Invalid backup password.", ex);
+        }
     }
 
     /// <summary>
@@ -106,16 +259,12 @@ public class PangoFileDataImporter : IDataImporter
     /// </summary>
     /// <param name="filePath"></param>
     /// <exception cref="PangoImportException"></exception>
-    private void ThrowIfFileIsNotValid(string filePath)
+    private static void ThrowIfFileIsNotValid(string filePath)
     {
         if (!System.IO.File.Exists(filePath))
-        {
-            throw new PangoImportException($"File {filePath} doesn't exist and cannot be imported");
-        }
+            throw new PangoImportException($"File {filePath} doesn't exist");
 
-        if(Path.GetExtension(filePath) != PackageFileExtension)
-        {
-            throw new PangoImportException($"Invalid file {filePath}: unsupported file extension");
-        }
+        if (Path.GetExtension(filePath) != PackageFileExtension)
+            throw new PangoImportException($"Invalid file extension");
     }
 }

--- a/src/Infrastructure/Pango.Persistence.File/PangoFileDataImporter.cs
+++ b/src/Infrastructure/Pango.Persistence.File/PangoFileDataImporter.cs
@@ -20,11 +20,18 @@ public class PangoFileDataImporter(
     private readonly IAppDomainProvider _appDomainProvider = appDomainProvider;
     private readonly IUserContextProvider _userContextProvider = userContextProvider;
     private readonly ILogger _logger = logger;
-    private static readonly SemaphoreSlim _semaphore = new(1, 1);
-    private const int MaxRetries = 3;
-    private const int DelayMiliseconds = 1000;
-    private const string PackageFileExtension = ".pngx";
 
+    private static readonly SemaphoreSlim _semaphore = new(1, 1);
+
+    private const int MaxRetries = 3;
+    private const int DelayMilliseconds = 1000;
+    private const string PackageFileExtension = ".pngx";
+    private const string DataFileExtension = ".pngdat";
+    private const string StaticSaltStr = "PangoStaticExportSalt";
+
+    /// <summary>
+    /// Orchestrates the import process by securing access and reading data.
+    /// </summary>
     public async Task<ImportResultDto> ImportAsync(string filePath, IImportOptions importOptions)
     {
         await _semaphore.WaitAsync();
@@ -40,6 +47,9 @@ public class PangoFileDataImporter(
         }
     }
 
+    /// <summary>
+    /// Reads and decrypts the package manifest from the zip archive.
+    /// </summary>
     public async Task<PangoPackageManifest> ReadManifestAsync(string filePath, IImportOptions importOptions)
     {
         ThrowIfFileIsNotValid(filePath);
@@ -64,18 +74,17 @@ public class PangoFileDataImporter(
             {
                 try
                 {
-                    _logger.LogDebug("Reading manifest from {filePath}", workingFilePath);
+                    if (_logger.IsEnabled(LogLevel.Debug))
+                    {
+                        _logger.LogDebug("Reading manifest from {filePath}", workingFilePath);
+                    }
+
                     using var fs = new FileStream(workingFilePath, FileMode.Open);
                     using var archive = new ZipArchive(fs, ZipArchiveMode.Read);
 
                     foreach (var entry in archive.Entries)
                     {
-                        // FIX: Ignore non-data files, system files, and folders
-                        if (string.IsNullOrEmpty(entry.Name) ||
-                            entry.FullName.StartsWith("_rels") ||
-                            entry.Name == "[Content_Types].xml" ||
-                            !entry.Name.EndsWith(".pngdat", StringComparison.OrdinalIgnoreCase))
-                            continue;
+                        if (ShouldSkipEntry(entry)) continue;
 
                         using var entryStream = entry.Open();
                         using var ms = new MemoryStream();
@@ -98,15 +107,16 @@ public class PangoFileDataImporter(
                         []
                     );
                 }
-                catch (PangoDataDecryptionException)
+                catch (PangoDataDecryptionException ex)
                 {
+                    _logger.LogError(ex, "Failed to decrypt manifest data.");
                     throw;
                 }
                 catch (IOException e)
                 {
-                    _logger.LogError("Manifest reading attempt {attempt} failed: {message}", attempt + 1, e.Message);
+                    _logger.LogError("Manifest reading attempt {Attempt} failed: {Message}", attempt + 1, e.Message);
                     if (attempt == MaxRetries - 1) throw;
-                    await Task.Delay(DelayMiliseconds);
+                    await Task.Delay(DelayMilliseconds);
                 }
             }
         }
@@ -114,13 +124,23 @@ public class PangoFileDataImporter(
         {
             if (!string.IsNullOrEmpty(tempDecryptedPath) && System.IO.File.Exists(tempDecryptedPath))
             {
-                try { System.IO.File.Delete(tempDecryptedPath); } catch { }
+                try
+                {
+                    System.IO.File.Delete(tempDecryptedPath);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to delete temporary decrypted file at {Path}", tempDecryptedPath);
+                }
             }
         }
 
         throw new PangoDataDecryptionException(ApplicationErrors.Data.DecryptionError, "Unable to read manifest from file.");
     }
 
+    /// <summary>
+    /// Extracts and decrypts content packages from the zip archive.
+    /// </summary>
     public async Task<List<IContentPackage>> ExtractContentAsync(string filePath, IImportOptions importOptions)
     {
         ThrowIfFileIsNotValid(filePath);
@@ -146,18 +166,17 @@ public class PangoFileDataImporter(
             {
                 try
                 {
-                    _logger.LogDebug("Extracting content from {filePath}", workingFilePath);
+                    if (_logger.IsEnabled(LogLevel.Debug))
+                    {
+                        _logger.LogDebug("Extracting content from {filePath}", workingFilePath);
+                    }
+
                     using var fs = new FileStream(workingFilePath, FileMode.Open);
                     using var archive = new ZipArchive(fs, ZipArchiveMode.Read);
 
                     foreach (var entry in archive.Entries)
                     {
-                        // FIX: Strict filter for .pngdat files only
-                        if (string.IsNullOrEmpty(entry.Name) ||
-                            entry.FullName.StartsWith("_rels") ||
-                            entry.Name == "[Content_Types].xml" ||
-                            !entry.Name.EndsWith(".pngdat", StringComparison.OrdinalIgnoreCase))
-                            continue;
+                        if (ShouldSkipEntry(entry)) continue;
 
                         using var entryStream = entry.Open();
                         using var ms = new MemoryStream();
@@ -179,15 +198,16 @@ public class PangoFileDataImporter(
                     }
                     break;
                 }
-                catch (PangoDataDecryptionException)
+                catch (PangoDataDecryptionException ex)
                 {
+                    _logger.LogError(ex, "Critical decryption failure during content extraction.");
                     throw;
                 }
                 catch (IOException e)
                 {
-                    _logger.LogError("Content extraction attempt {attempt} failed: {message}", attempt + 1, e.Message);
+                    _logger.LogError("Content extraction attempt {Attempt} failed: {Message}", attempt + 1, e.Message);
                     if (attempt == MaxRetries - 1) throw;
-                    await Task.Delay(DelayMiliseconds);
+                    await Task.Delay(DelayMilliseconds);
                 }
             }
         }
@@ -195,7 +215,14 @@ public class PangoFileDataImporter(
         {
             if (!string.IsNullOrEmpty(tempDecryptedPath) && System.IO.File.Exists(tempDecryptedPath))
             {
-                try { System.IO.File.Delete(tempDecryptedPath); } catch { }
+                try
+                {
+                    System.IO.File.Delete(tempDecryptedPath);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to delete temporary content file at {Path}", tempDecryptedPath);
+                }
             }
             _logger.LogDebug("Content extraction completed");
         }
@@ -203,17 +230,34 @@ public class PangoFileDataImporter(
         return importedPackages;
     }
 
+    /// <summary>
+    /// Helper to filter out system files and non-data entries from the archive.
+    /// </summary>
+    private static bool ShouldSkipEntry(ZipArchiveEntry entry)
+    {
+        return string.IsNullOrEmpty(entry.Name) ||
+               entry.FullName.StartsWith("_rels") ||
+               entry.Name == "[Content_Types].xml" ||
+               !entry.Name.EndsWith(DataFileExtension, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Checks if the file is a standard Zip or an encrypted backup.
+    /// </summary>
     private static async Task<bool> IsEncryptedBackupFileAsync(string filePath)
     {
         try
         {
             using (ZipFile.OpenRead(filePath)) { }
-            return false;
+            return await Task.FromResult(false);
         }
         catch (InvalidDataException) { return true; }
         catch (Exception) { return true; }
     }
 
+    /// <summary>
+    /// Attempts to decrypt raw byte data into a strongly typed object.
+    /// </summary>
     private async Task<T?> TryDecrypt<T>(byte[] data, EncodingOptions options)
     {
         if (string.IsNullOrEmpty(options.Key)) return default;
@@ -226,18 +270,21 @@ public class PangoFileDataImporter(
 
         if (!isValidKey)
         {
-            byte[] staticSalt = Encoding.UTF8.GetBytes("PangoStaticExportSalt");
-            using var derive = new Rfc2898DeriveBytes(options.Key, staticSalt, 50000, HashAlgorithmName.SHA256);
-            keyBase64 = Convert.ToBase64String(derive.GetBytes(32));
-            saltBase64 = Convert.ToBase64String(derive.GetBytes(16));
+            byte[] staticSalt = Encoding.UTF8.GetBytes(StaticSaltStr);
+
+            byte[] derivedBytes = Rfc2898DeriveBytes.Pbkdf2(Encoding.UTF8.GetBytes(options.Key), staticSalt, 50000, HashAlgorithmName.SHA256, 48);
+
+            keyBase64 = Convert.ToBase64String(derivedBytes[0..32]);
+            saltBase64 = Convert.ToBase64String(derivedBytes[32..48]);
         }
 
         try
         {
             return await _contentEncoder.DecryptAsync<T>(data, keyBase64, saltBase64);
         }
-        catch (PangoDataDecryptionException)
+        catch (PangoDataDecryptionException ex)
         {
+            _logger.LogError(ex, "Decryption failed for internal data block.");
             throw;
         }
         catch (Exception ex)
@@ -247,6 +294,9 @@ public class PangoFileDataImporter(
         }
     }
 
+    /// <summary>
+    /// Decrypts the entire backup file using AES-256 and writes to output.
+    /// </summary>
     private static async Task DecryptBackupFileAsync(string inputFile, string outputFile, string password)
     {
         await using var fsInput = new FileStream(inputFile, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true);
@@ -256,8 +306,7 @@ public class PangoFileDataImporter(
         byte[] iv = new byte[16];
         if (await fsInput.ReadAsync(iv.AsMemory(0, 16)) < 16) throw new IOException("Invalid header");
 
-        using var kdf = new Rfc2898DeriveBytes(password, salt, 50000, HashAlgorithmName.SHA256);
-        byte[] key = kdf.GetBytes(32);
+        byte[] key = Rfc2898DeriveBytes.Pbkdf2(Encoding.UTF8.GetBytes(password), salt, 50000, HashAlgorithmName.SHA256, 32);
 
         using var aes = Aes.Create();
         aes.Key = key;
@@ -277,10 +326,8 @@ public class PangoFileDataImporter(
     }
 
     /// <summary>
-    /// Throws <see cref="PangoImportException"/> if file <paramref name="filePath"/> is not valid
+    /// Validates file existence and extension.
     /// </summary>
-    /// <param name="filePath"></param>
-    /// <exception cref="PangoImportException"></exception>
     private static void ThrowIfFileIsNotValid(string filePath)
     {
         if (!System.IO.File.Exists(filePath)) throw new PangoImportException($"File {filePath} doesn't exist");

--- a/src/Infrastructure/Pango.Persistence.File/PangoFileDataImporter.cs
+++ b/src/Infrastructure/Pango.Persistence.File/PangoFileDataImporter.cs
@@ -20,114 +20,161 @@ public class PangoFileDataImporter(
     private readonly IAppDomainProvider _appDomainProvider = appDomainProvider;
     private readonly IUserContextProvider _userContextProvider = userContextProvider;
     private readonly ILogger _logger = logger;
-
-    private static readonly SemaphoreSlim _semaphore = new (1, 1);
+    private static readonly SemaphoreSlim _semaphore = new(1, 1);
     private const int MaxRetries = 3;
     private const int DelayMiliseconds = 1000;
     private const string PackageFileExtension = ".pngx";
 
     public async Task<ImportResultDto> ImportAsync(string filePath, IImportOptions importOptions)
     {
-        List<IContentPackage> importedPackages = [];
-        PangoPackageManifest? manifest = null;
-
         await _semaphore.WaitAsync();
+        try
+        {
+            var manifest = await ReadManifestAsync(filePath, importOptions);
+            var content = await ExtractContentAsync(filePath, importOptions);
+            return new ImportResultDto(manifest, content);
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
 
+    public async Task<PangoPackageManifest> ReadManifestAsync(string filePath, IImportOptions importOptions)
+    {
+        ThrowIfFileIsNotValid(filePath);
+        bool isEncryptedBackup = await IsEncryptedBackupFileAsync(filePath);
+        string workingFilePath = filePath;
         string tempDecryptedPath = string.Empty;
 
         try
         {
-            ThrowIfFileIsNotValid(filePath);
-
-            // 1. Detect if the file is a standard Zip (Export) or Encrypted (Backup)
-            bool isEncryptedBackup = false;
-            try
-            {
-                using (ZipFile.OpenRead(filePath)) { }
-            }
-            catch (InvalidDataException)
-            {
-                isEncryptedBackup = true;
-            }
-            catch (Exception)
-            {
-                isEncryptedBackup = true;
-            }
-
-            string workingFilePath = filePath;
-
-            // 2. Decrypt Backup Container (if applicable)
             if (isEncryptedBackup)
             {
                 _logger.LogInformation("File appears encrypted. Attempting backup decryption...");
                 tempDecryptedPath = Path.GetTempFileName();
-
                 string backupPassword = importOptions.EncodingOptions.Key;
-
-                try
-                {
-                    await DecryptBackupFileAsync(filePath, tempDecryptedPath, backupPassword);
-                    workingFilePath = tempDecryptedPath;
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Backup decryption failed.");
-                    throw new PangoDataDecryptionException(ApplicationErrors.Data.DecryptionError, "Invalid backup password.", ex);
-                }
+                await DecryptBackupFileAsync(filePath, tempDecryptedPath, backupPassword);
+                workingFilePath = tempDecryptedPath;
             }
 
-            // Get User Keys
             EncodingOptions userOptions = await _userContextProvider.GetEncodingOptionsAsync();
 
-            // 3. Process the Archive
             for (int attempt = 0; attempt < MaxRetries; attempt++)
             {
                 try
                 {
-                    _logger.LogDebug("Reading archive from {filePath}", workingFilePath);
-
+                    _logger.LogDebug("Reading manifest from {filePath}", workingFilePath);
                     using var fs = new FileStream(workingFilePath, FileMode.Open);
+                    using var archive = new ZipArchive(fs, ZipArchiveMode.Read);
 
-                    ZipArchive archive;
-                    try
+                    foreach (var entry in archive.Entries)
                     {
-                        archive = new ZipArchive(fs, ZipArchiveMode.Read);
-                    }
-                    catch (InvalidDataException)
-                    {
-                        throw new PangoDataDecryptionException(ApplicationErrors.Data.DecryptionError, "Wrong password (archive is invalid).");
-                    }
+                        // FIX: Ignore non-data files, system files, and folders
+                        if (string.IsNullOrEmpty(entry.Name) ||
+                            entry.FullName.StartsWith("_rels") ||
+                            entry.Name == "[Content_Types].xml" ||
+                            !entry.Name.EndsWith(".pngdat", StringComparison.OrdinalIgnoreCase))
+                            continue;
 
-                    using (archive)
-                    {
-                        foreach (var entry in archive.Entries)
+                        using var entryStream = entry.Open();
+                        using var ms = new MemoryStream();
+                        await entryStream.CopyToAsync(ms);
+                        byte[] encryptedData = ms.ToArray();
+
+                        var decryptionOptions = isEncryptedBackup ? userOptions : importOptions.EncodingOptions;
+                        var manifest = await TryDecrypt<PangoPackageManifest>(encryptedData, decryptionOptions);
+
+                        if (!manifest.Equals(default))
                         {
-                            if (entry.Name == "[Content_Types].xml" || entry.FullName.StartsWith("_rels") || string.IsNullOrEmpty(entry.Name))
-                                continue;
+                            return manifest;
+                        }
+                    }
 
-                            using var entryStream = entry.Open();
-                            using var ms = new MemoryStream();
-                            await entryStream.CopyToAsync(ms);
-                            byte[] encryptedData = ms.ToArray();
+                    return new PangoPackageManifest(
+                        _userContextProvider.GetUserName(),
+                        DateTime.UtcNow.ToString("G"),
+                        "Restored from Backup",
+                        []
+                    );
+                }
+                catch (PangoDataDecryptionException)
+                {
+                    throw;
+                }
+                catch (IOException e)
+                {
+                    _logger.LogError("Manifest reading attempt {attempt} failed: {message}", attempt + 1, e.Message);
+                    if (attempt == MaxRetries - 1) throw;
+                    await Task.Delay(DelayMiliseconds);
+                }
+            }
+        }
+        finally
+        {
+            if (!string.IsNullOrEmpty(tempDecryptedPath) && System.IO.File.Exists(tempDecryptedPath))
+            {
+                try { System.IO.File.Delete(tempDecryptedPath); } catch { }
+            }
+        }
 
-                            var decryptionOptions = isEncryptedBackup ? userOptions : importOptions.EncodingOptions;
+        throw new PangoDataDecryptionException(ApplicationErrors.Data.DecryptionError, "Unable to read manifest from file.");
+    }
 
-                            if (manifest == null)
-                            {
-                                manifest = await TryDecrypt<PangoPackageManifest>(encryptedData, decryptionOptions);
-                            }
+    public async Task<List<IContentPackage>> ExtractContentAsync(string filePath, IImportOptions importOptions)
+    {
+        ThrowIfFileIsNotValid(filePath);
+        List<IContentPackage> importedPackages = [];
+        bool isEncryptedBackup = await IsEncryptedBackupFileAsync(filePath);
+        string workingFilePath = filePath;
+        string tempDecryptedPath = string.Empty;
 
-                            IContentPackage? data = await TryDecrypt<ContentPackage>(encryptedData, decryptionOptions);
+        try
+        {
+            if (isEncryptedBackup)
+            {
+                _logger.LogInformation("File appears encrypted. Attempting backup decryption...");
+                tempDecryptedPath = Path.GetTempFileName();
+                string backupPassword = importOptions.EncodingOptions.Key;
+                await DecryptBackupFileAsync(filePath, tempDecryptedPath, backupPassword);
+                workingFilePath = tempDecryptedPath;
+            }
 
-                            if (data == null && !isEncryptedBackup)
-                            {
-                                data = await TryDecrypt<ContentPackage>(encryptedData, userOptions);
-                            }
+            EncodingOptions userOptions = await _userContextProvider.GetEncodingOptionsAsync();
 
-                            if (data != null)
-                            {
-                                importedPackages.Add(data);
-                            }
+            for (int attempt = 0; attempt < MaxRetries; attempt++)
+            {
+                try
+                {
+                    _logger.LogDebug("Extracting content from {filePath}", workingFilePath);
+                    using var fs = new FileStream(workingFilePath, FileMode.Open);
+                    using var archive = new ZipArchive(fs, ZipArchiveMode.Read);
+
+                    foreach (var entry in archive.Entries)
+                    {
+                        // FIX: Strict filter for .pngdat files only
+                        if (string.IsNullOrEmpty(entry.Name) ||
+                            entry.FullName.StartsWith("_rels") ||
+                            entry.Name == "[Content_Types].xml" ||
+                            !entry.Name.EndsWith(".pngdat", StringComparison.OrdinalIgnoreCase))
+                            continue;
+
+                        using var entryStream = entry.Open();
+                        using var ms = new MemoryStream();
+                        await entryStream.CopyToAsync(ms);
+                        byte[] encryptedData = ms.ToArray();
+
+                        var decryptionOptions = isEncryptedBackup ? userOptions : importOptions.EncodingOptions;
+                        IContentPackage? data = await TryDecrypt<ContentPackage>(encryptedData, decryptionOptions);
+
+                        if (data == null && !isEncryptedBackup)
+                        {
+                            data = await TryDecrypt<ContentPackage>(encryptedData, userOptions);
+                        }
+
+                        if (data != null)
+                        {
+                            importedPackages.Add(data);
                         }
                     }
                     break;
@@ -138,9 +185,9 @@ public class PangoFileDataImporter(
                 }
                 catch (IOException e)
                 {
-                    _logger.LogError("Import attempt {attempt} failed: {message}", attempt + 1, e.Message);
-                    await Task.Delay(DelayMiliseconds);
+                    _logger.LogError("Content extraction attempt {attempt} failed: {message}", attempt + 1, e.Message);
                     if (attempt == MaxRetries - 1) throw;
+                    await Task.Delay(DelayMiliseconds);
                 }
             }
         }
@@ -150,42 +197,21 @@ public class PangoFileDataImporter(
             {
                 try { System.IO.File.Delete(tempDecryptedPath); } catch { }
             }
-            _logger.LogDebug("Import completed");
-            _semaphore.Release();
+            _logger.LogDebug("Content extraction completed");
         }
 
-        if (manifest is null && importedPackages.Count == 0)
+        return importedPackages;
+    }
+
+    private static async Task<bool> IsEncryptedBackupFileAsync(string filePath)
+    {
+        try
         {
-            throw new PangoDataDecryptionException(ApplicationErrors.Data.DecryptionError, "Wrong password or invalid file format.");
+            using (ZipFile.OpenRead(filePath)) { }
+            return false;
         }
-
-        // 4. Construct Result
-        if (manifest is null)
-        {
-            if (importedPackages.Count > 0)
-            {
-                manifest = new PangoPackageManifest(
-                    _userContextProvider.GetUserName(),
-                    DateTime.UtcNow.ToString("G"),
-                    "Restored from Backup",
-                    new Dictionary<Domain.Enums.ContentType, int> { { Domain.Enums.ContentType.Passwords, importedPackages.Count } }
-                );
-            }
-            else
-            {
-                throw new PangoImportException("Import failed: No valid data found. Wrong password or wrong user account.");
-            }
-        }
-
-        var finalManifest = manifest.Value;
-        finalManifest.Contents ??= [];
-
-        if (importedPackages.Count > 0 && (!finalManifest.Contents.ContainsKey(Domain.Enums.ContentType.Passwords) || finalManifest.Contents[Domain.Enums.ContentType.Passwords] == 0))
-        {
-            finalManifest.Contents[Domain.Enums.ContentType.Passwords] = importedPackages.Count;
-        }
-
-        return new ImportResultDto(finalManifest, importedPackages);
+        catch (InvalidDataException) { return true; }
+        catch (Exception) { return true; }
     }
 
     private async Task<T?> TryDecrypt<T>(byte[] data, EncodingOptions options)
@@ -224,14 +250,11 @@ public class PangoFileDataImporter(
     private static async Task DecryptBackupFileAsync(string inputFile, string outputFile, string password)
     {
         await using var fsInput = new FileStream(inputFile, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true);
-
         byte[] salt = new byte[16];
-        if (await fsInput.ReadAsync(salt.AsMemory(0, 16)) < 16)
-            throw new IOException("Invalid header");
+        if (await fsInput.ReadAsync(salt.AsMemory(0, 16)) < 16) throw new IOException("Invalid header");
 
         byte[] iv = new byte[16];
-        if (await fsInput.ReadAsync(iv.AsMemory(0, 16)) < 16)
-            throw new IOException("Invalid header");
+        if (await fsInput.ReadAsync(iv.AsMemory(0, 16)) < 16) throw new IOException("Invalid header");
 
         using var kdf = new Rfc2898DeriveBytes(password, salt, 50000, HashAlgorithmName.SHA256);
         byte[] key = kdf.GetBytes(32);
@@ -243,7 +266,6 @@ public class PangoFileDataImporter(
 
         await using var fsOutput = new FileStream(outputFile, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true);
         await using var cs = new CryptoStream(fsInput, aes.CreateDecryptor(), CryptoStreamMode.Read);
-
         try
         {
             await cs.CopyToAsync(fsOutput);
@@ -261,10 +283,7 @@ public class PangoFileDataImporter(
     /// <exception cref="PangoImportException"></exception>
     private static void ThrowIfFileIsNotValid(string filePath)
     {
-        if (!System.IO.File.Exists(filePath))
-            throw new PangoImportException($"File {filePath} doesn't exist");
-
-        if (Path.GetExtension(filePath) != PackageFileExtension)
-            throw new PangoImportException($"Invalid file extension");
+        if (!System.IO.File.Exists(filePath)) throw new PangoImportException($"File {filePath} doesn't exist");
+        if (Path.GetExtension(filePath) != PackageFileExtension) throw new PangoImportException($"Invalid file extension");
     }
 }

--- a/src/Infrastructure/Pango.Persistence.File/PasswordFileRepository.cs
+++ b/src/Infrastructure/Pango.Persistence.File/PasswordFileRepository.cs
@@ -23,22 +23,9 @@ public class PasswordFileRepository(
 
         var passwordList = (await ExtractAllItemsForUserAsync(Path.Combine(ctx.WorkingDirectoryPath, DirectoryName), ctx.EncodingOptions)).ToList();
 
-        bool alreadyExists = passwordList.Any(p =>
-            p.Name.Equals(password.Name, StringComparison.OrdinalIgnoreCase) &&
-            (p.CatalogPath ?? string.Empty).Equals(password.CatalogPath ?? string.Empty, StringComparison.OrdinalIgnoreCase) &&
-            p.IsCatalog == password.IsCatalog &&
-            (password.IsCatalog || (p.Login ?? string.Empty).Equals(password.Login ?? string.Empty, StringComparison.OrdinalIgnoreCase))
-        );
-
-        if (alreadyExists)
-        {
-            Logger.LogInformation("Item {name} in {path} (IsCatalog: {isCat}) already exists. Skipping.",
-                password.Name, password.CatalogPath, password.IsCatalog);
-            return;
-        }
-
         password.UserName = ctx.UserId;
         passwordList.Add(password);
+
         await SaveItemsForUserAsync(passwordList, ctx.UserId, Path.Combine(ctx.WorkingDirectoryPath, DirectoryName), ctx.EncodingOptions);
     }
 
@@ -53,19 +40,10 @@ public class PasswordFileRepository(
 
         foreach (var newItem in passwords)
         {
-            bool exists = passwordList.Any(p =>
-                p.Name.Equals(newItem.Name, StringComparison.OrdinalIgnoreCase) &&
-                (p.CatalogPath ?? string.Empty).Equals(newItem.CatalogPath ?? string.Empty, StringComparison.OrdinalIgnoreCase) &&
-                p.IsCatalog == newItem.IsCatalog &&
-                (newItem.IsCatalog || (p.Login ?? string.Empty).Equals(newItem.Login ?? string.Empty, StringComparison.OrdinalIgnoreCase))
-            );
-
-            if (!exists)
-            {
-                newItem.UserName = ctx.UserId;
-                passwordList.Add(newItem);
-            }
+            newItem.UserName = ctx.UserId;
+            passwordList.Add(newItem);
         }
+
         await SaveItemsForUserAsync(passwordList, ctx.UserId, Path.Combine(ctx.WorkingDirectoryPath, DirectoryName), ctx.EncodingOptions);
     }
 
@@ -77,8 +55,9 @@ public class PasswordFileRepository(
         }
 
         var passwordList = (await ExtractAllItemsForUserAsync(Path.Combine(ctx.WorkingDirectoryPath, DirectoryName), ctx.EncodingOptions)).ToList();
+
         var pwdToUpdate = passwordList.FirstOrDefault(p => p.Id == password.Id)
-            ?? throw new PasswordNotFoundException($"Pango password with ID \"{password.Id}\" not found");
+                          ?? throw new PasswordNotFoundException($"Pango password with ID \"{password.Id}\" not found");
 
         pwdToUpdate.Name = password.Name;
         pwdToUpdate.Login = password.Login;
@@ -90,6 +69,7 @@ public class PasswordFileRepository(
         pwdToUpdate.LastModifiedAt = DateTimeOffset.UtcNow;
 
         await SaveItemsForUserAsync(passwordList, ctx.UserId, Path.Combine(ctx.WorkingDirectoryPath, DirectoryName), ctx.EncodingOptions);
+
         return pwdToUpdate;
     }
 
@@ -101,8 +81,8 @@ public class PasswordFileRepository(
         }
 
         var passwordList = (await ExtractAllItemsForUserAsync(Path.Combine(ctx.WorkingDirectoryPath, DirectoryName), ctx.EncodingOptions)).ToList();
-        var pwdToRemove = passwordList.FirstOrDefault(p => p.Id == password.Id);
 
+        var pwdToRemove = passwordList.FirstOrDefault(p => p.Id == password.Id);
         if (pwdToRemove != null)
         {
             passwordList.Remove(pwdToRemove);

--- a/src/Infrastructure/Pango.Persistence.File/PasswordFileRepository.cs
+++ b/src/Infrastructure/Pango.Persistence.File/PasswordFileRepository.cs
@@ -1,6 +1,4 @@
-﻿using ErrorOr;
-using Microsoft.Extensions.Logging;
-using Pango.Application.Common;
+﻿using Microsoft.Extensions.Logging;
 using Pango.Application.Common.Exceptions;
 using Pango.Application.Common.Interfaces;
 using Pango.Application.Common.Interfaces.Persistence;
@@ -8,35 +6,40 @@ using Pango.Domain.Entities;
 
 namespace Pango.Persistence.File;
 
-public class PasswordFileRepository : FileRepositoryBase<PangoPassword>, IPasswordRepository
+public class PasswordFileRepository(
+    IContentEncoder contentEncoder,
+    IAppDomainProvider appDomainProvider,
+    ILogger<PasswordFileRepository> logger,
+    IAppOptions appOptions) : FileRepositoryBase<PangoPassword>(contentEncoder, appDomainProvider, appOptions, logger), IPasswordRepository
 {
     protected override string DirectoryName => "passwords";
-    
-    public PasswordFileRepository(IContentEncoder contentEncoder,
-        IAppDomainProvider appDomainProvider,
-        ILogger<PasswordFileRepository> logger,
-        IAppOptions appOptions)
-        : base(contentEncoder, appDomainProvider, appOptions, logger)
-    { }
 
     public async Task CreateAsync(PangoPassword password, IRepositoryActionContext context)
     {
-        if(context is not FileRepositoryActionContext ctx)
+        if (context is not FileRepositoryActionContext ctx)
         {
-            throw new ArgumentException($"Invalid type of context. It must be {typeof(FileRepositoryActionContext).FullName}", nameof(context));       
+            throw new ArgumentException($"Invalid type of context. It must be {typeof(FileRepositoryActionContext).FullName}", nameof(context));
         }
 
         var passwordList = (await ExtractAllItemsForUserAsync(Path.Combine(ctx.WorkingDirectoryPath, DirectoryName), ctx.EncodingOptions)).ToList();
 
-        if (password.IsCatalog && passwordList.Any(p => p.Name.Equals(password.CatalogPath) && p.CatalogPath.Equals(password.CatalogPath)))
+        bool alreadyExists = passwordList.Any(p =>
+            p.Name.Equals(password.Name, StringComparison.OrdinalIgnoreCase) &&
+            (p.CatalogPath ?? string.Empty).Equals(password.CatalogPath ?? string.Empty, StringComparison.OrdinalIgnoreCase) &&
+            p.IsCatalog == password.IsCatalog &&
+            (password.IsCatalog || (p.Login ?? string.Empty).Equals(password.Login ?? string.Empty, StringComparison.OrdinalIgnoreCase))
+        );
+
+        if (alreadyExists)
         {
-            Logger.LogInformation("Catalog {catalog} cannot be created: there is already a catalog with the same name.", password.Name);
+            Logger.LogInformation("Item {name} in {path} (IsCatalog: {isCat}) already exists. Skipping.",
+                password.Name, password.CatalogPath, password.IsCatalog);
             return;
         }
 
+        password.UserName = ctx.UserId;
         passwordList.Add(password);
-
-        await SaveItemsForUserAsync(passwordList, password.UserName, Path.Combine(ctx.WorkingDirectoryPath, DirectoryName), ctx.EncodingOptions);
+        await SaveItemsForUserAsync(passwordList, ctx.UserId, Path.Combine(ctx.WorkingDirectoryPath, DirectoryName), ctx.EncodingOptions);
     }
 
     public async Task CreateAsync(IEnumerable<PangoPassword> passwords, IRepositoryActionContext context)
@@ -48,18 +51,21 @@ public class PasswordFileRepository : FileRepositoryBase<PangoPassword>, IPasswo
 
         var passwordList = (await ExtractAllItemsForUserAsync(Path.Combine(ctx.WorkingDirectoryPath, DirectoryName), ctx.EncodingOptions)).ToList();
 
-        foreach(var newPassword in passwords)
+        foreach (var newItem in passwords)
         {
-            if(newPassword.IsCatalog && passwordList.Any(p => p.Name.Equals(newPassword.Name) && p.CatalogPath.Equals(newPassword.CatalogPath)))
+            bool exists = passwordList.Any(p =>
+                p.Name.Equals(newItem.Name, StringComparison.OrdinalIgnoreCase) &&
+                (p.CatalogPath ?? string.Empty).Equals(newItem.CatalogPath ?? string.Empty, StringComparison.OrdinalIgnoreCase) &&
+                p.IsCatalog == newItem.IsCatalog &&
+                (newItem.IsCatalog || (p.Login ?? string.Empty).Equals(newItem.Login ?? string.Empty, StringComparison.OrdinalIgnoreCase))
+            );
+
+            if (!exists)
             {
-                Logger.LogInformation("Catalog {catalog} cannot be created: there is already a catalog with the same name.", newPassword.Name);
-                continue;
+                newItem.UserName = ctx.UserId;
+                passwordList.Add(newItem);
             }
-
-            newPassword.UserName = ctx.UserId;
-            passwordList.Add(newPassword);
         }
-
         await SaveItemsForUserAsync(passwordList, ctx.UserId, Path.Combine(ctx.WorkingDirectoryPath, DirectoryName), ctx.EncodingOptions);
     }
 
@@ -71,18 +77,19 @@ public class PasswordFileRepository : FileRepositoryBase<PangoPassword>, IPasswo
         }
 
         var passwordList = (await ExtractAllItemsForUserAsync(Path.Combine(ctx.WorkingDirectoryPath, DirectoryName), ctx.EncodingOptions)).ToList();
-        
-        var pwdToUpdate = passwordList.FirstOrDefault(p => p.Id == password.Id) ?? throw new PasswordNotFoundException($"Pango password with ID \"{password.Id}\" not found");
+        var pwdToUpdate = passwordList.FirstOrDefault(p => p.Id == password.Id)
+            ?? throw new PasswordNotFoundException($"Pango password with ID \"{password.Id}\" not found");
+
         pwdToUpdate.Name = password.Name;
         pwdToUpdate.Login = password.Login;
         pwdToUpdate.Properties = password.Properties;
         pwdToUpdate.Value = password.Value;
         pwdToUpdate.Target = password.Target;
         pwdToUpdate.CatalogPath = password.CatalogPath;
+        pwdToUpdate.IsCatalog = password.IsCatalog;
         pwdToUpdate.LastModifiedAt = DateTimeOffset.UtcNow;
 
-        await SaveItemsForUserAsync(passwordList, password.UserName, Path.Combine(ctx.WorkingDirectoryPath, DirectoryName), ctx.EncodingOptions);
-
+        await SaveItemsForUserAsync(passwordList, ctx.UserId, Path.Combine(ctx.WorkingDirectoryPath, DirectoryName), ctx.EncodingOptions);
         return pwdToUpdate;
     }
 
@@ -96,10 +103,10 @@ public class PasswordFileRepository : FileRepositoryBase<PangoPassword>, IPasswo
         var passwordList = (await ExtractAllItemsForUserAsync(Path.Combine(ctx.WorkingDirectoryPath, DirectoryName), ctx.EncodingOptions)).ToList();
         var pwdToRemove = passwordList.FirstOrDefault(p => p.Id == password.Id);
 
-        if (pwdToRemove != null) 
+        if (pwdToRemove != null)
         {
             passwordList.Remove(pwdToRemove);
-            await SaveItemsForUserAsync(passwordList, password.UserName, Path.Combine(ctx.WorkingDirectoryPath, DirectoryName), ctx.EncodingOptions);
+            await SaveItemsForUserAsync(passwordList, ctx.UserId, Path.Combine(ctx.WorkingDirectoryPath, DirectoryName), ctx.EncodingOptions);
         }
     }
 
@@ -110,7 +117,8 @@ public class PasswordFileRepository : FileRepositoryBase<PangoPassword>, IPasswo
             throw new ArgumentException($"Invalid type of context. It must be {typeof(FileRepositoryActionContext).FullName}", nameof(context));
         }
 
-        return (await ExtractAllItemsForUserAsync(Path.Combine(ctx.WorkingDirectoryPath, DirectoryName), ctx.EncodingOptions)).FirstOrDefault(predicate);
+        var items = await ExtractAllItemsForUserAsync(Path.Combine(ctx.WorkingDirectoryPath, DirectoryName), ctx.EncodingOptions);
+        return items.FirstOrDefault(predicate);
     }
 
     public async Task<IEnumerable<PangoPassword>> QueryAsync(Func<PangoPassword, bool> predicate, IRepositoryActionContext context)
@@ -120,6 +128,7 @@ public class PasswordFileRepository : FileRepositoryBase<PangoPassword>, IPasswo
             throw new ArgumentException($"Invalid type of context. It must be {typeof(FileRepositoryActionContext).FullName}", nameof(context));
         }
 
-        return (await ExtractAllItemsForUserAsync(Path.Combine(ctx.WorkingDirectoryPath, DirectoryName), ctx.EncodingOptions)).Where(predicate);
+        var items = await ExtractAllItemsForUserAsync(Path.Combine(ctx.WorkingDirectoryPath, DirectoryName), ctx.EncodingOptions);
+        return items.Where(predicate);
     }
 }

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Core/Utility/TreeBuilder.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Core/Utility/TreeBuilder.cs
@@ -1,0 +1,92 @@
+﻿using Pango.Application.Common;
+using Pango.Desktop.Uwp.Models;
+using Pango.Domain.Entities;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Pango.Desktop.Uwp.Core.Utility;
+
+public static class TreeBuilder
+{
+    // Constructs the hierarchical tree from a flat list of passwords.
+    public static ObservableCollection<PangoExplorerItem> BuildTree(List<PangoPassword> flatList)
+    {
+        var validItems = flatList.Where(x => !string.IsNullOrWhiteSpace(x.Name)).ToList();
+        var folders = validItems.Where(x => x.IsCatalog).ToList();
+        var files = validItems.Where(x => !x.IsCatalog).ToList();
+
+        var folderMap = new Dictionary<string, PangoExplorerItem>(StringComparer.OrdinalIgnoreCase);
+
+        // create folder nodes
+        foreach (var f in folders)
+        {
+            string fullPath = GetEntityFullPath(f);
+            if (!folderMap.ContainsKey(fullPath))
+            {
+                folderMap[fullPath] = new PangoExplorerItem(f.Id, f.Name, PangoExplorerItem.ExplorerItemType.Folder)
+                {
+                    CatalogPath = f.CatalogPath?.Trim() ?? string.Empty,
+                    IsSelected = false
+                };
+            }
+        }
+
+        var rootItems = new ObservableCollection<PangoExplorerItem>();
+        var allItemsToProcess = new List<PangoExplorerItem>(folderMap.Values);
+
+        // create file nodes
+        foreach (var f in files)
+        {
+            allItemsToProcess.Add(new PangoExplorerItem(f.Id, f.Name, PangoExplorerItem.ExplorerItemType.File)
+            {
+                CatalogPath = f.CatalogPath?.Trim() ?? string.Empty,
+                IsSelected = false
+            });
+        }
+
+        // link items to parents
+        foreach (var item in allItemsToProcess)
+        {
+            if (string.IsNullOrEmpty(item.CatalogPath))
+            {
+                rootItems.Add(item);
+            }
+            else
+            {
+                if (folderMap.TryGetValue(item.CatalogPath, out var parentFolder))
+                {
+                    parentFolder.AddChild(item);
+                }
+                else
+                {
+                }
+            }
+        }
+
+        SortChildren(rootItems);
+        return rootItems;
+    }
+
+    // Recursively sorts the tree structure.
+    private static void SortChildren(ObservableCollection<PangoExplorerItem> items)
+    {
+        var sorted = items.OrderByDescending(x => x.Type == PangoExplorerItem.ExplorerItemType.Folder)
+                          .ThenBy(x => x.Name)
+                          .ToList();
+        items.Clear();
+        foreach (var item in sorted)
+        {
+            if (item.Children.Count > 0) SortChildren(item.Children);
+            items.Add(item);
+        }
+    }
+
+    // Helper to get full path string.
+    private static string GetEntityFullPath(PangoPassword item)
+    {
+        if (string.IsNullOrEmpty(item.CatalogPath)) return item.Name;
+        return $"{item.CatalogPath}{AppConstants.CatalogDelimeter}{item.Name}";
+    }
+}

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Dialogs/Parameters/ImportDataParameters.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Dialogs/Parameters/ImportDataParameters.cs
@@ -1,6 +1,19 @@
-﻿namespace Pango.Desktop.Uwp.Dialogs.Parameters;
+﻿using Pango.Desktop.Uwp.Models.Parameters;
+using Pango.Domain.Entities;
+using System;
+using System.Collections.Generic;
 
-public class ImportDataParameters(string filePath) : IDialogParameter
+namespace Pango.Desktop.Uwp.Dialogs.Parameters;
+
+// Defines parameters for data import dialog
+public class ImportDataParameters(string filePath, IEnumerable<PangoPassword>? preLoadedContent = null) : IDialogParameter, INavigationParameter
 {
     public string FilePath { get; } = filePath;
+    public IEnumerable<PangoPassword> PreLoadedContent { get; } = preLoadedContent ?? [];
+    public List<Guid> SelectedItems { get; set; } = [];
+}
+
+public class ImportDataParametersWithPassword(string filePath, string password, IEnumerable<PangoPassword> content) : ImportDataParameters(filePath, content)
+{
+    public string Password { get; } = password;
 }

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Dialogs/ViewModels/ExportDialogViewModel.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Dialogs/ViewModels/ExportDialogViewModel.cs
@@ -1,4 +1,4 @@
-using CommunityToolkit.Mvvm.Messaging;
+﻿using CommunityToolkit.Mvvm.Messaging;
 using ErrorOr;
 using MediatR;
 using Microsoft.Extensions.Logging;

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Dialogs/ViewModels/ExportDialogViewModel.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Dialogs/ViewModels/ExportDialogViewModel.cs
@@ -13,6 +13,7 @@ using Pango.Desktop.Uwp.ViewModels;
 using Pango.Persistence.File;
 using System;
 using System.IO;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -104,57 +105,69 @@ public partial class ExportDialogViewModel : ViewModelBase, IDialogViewModel
     public async Task OnSaveAsync()
     {
         Validator.Validate();
-        if (Validator.HasErrors)
+        if (Validator.HasErrors) return;
+        if (_parameters is null) return;
+
+        string masterPassword = Validator.MasterPassword;
+        string description = Validator.Description;
+        string exportPath = Validator.ExportFolderPath;
+        string fileName = Validator.FileName;
+        var itemsToExport = _parameters.Items;
+
+        var exportResult = await Task.Run<(bool Success, string? ErrorMessage, ExportResult? Result)>(async () =>
         {
-            return;
-        }
-
-        if (_parameters is null)
-        {
-            Logger.LogError("Cannot do the export: ExportDataParameters is null");
-            return;
-        }
-
-        var saltBytes = Encoding.UTF8.GetBytes(Validator.MasterPassword);
-        Array.Resize(ref saltBytes, 16);
-        string passwordHash = _passwordHashProvider.Hash(Validator.MasterPassword, saltBytes);
-        var encoding = new EncodingOptions(passwordHash, Convert.ToBase64String(saltBytes));
-
-        ErrorOr<ExportResult> result = await _sender.Send(new ExportDataCommand(_parameters.Items, new ExportOptions(Validator.Description, encoding)));
-
-        if (result.IsError)
-        {
-            WeakReferenceMessenger.Default.Send(new InAppNotificationMessage($"Export failed: {result.FirstError}", Core.Enums.AppNotificationType.Error));
-        }
-        else
-        {
-            var sourcePath = result.Value.Path;
-            string fullDestinationPath = Path.Combine(Validator.ExportFolderPath, $"{Validator.FileName}{FileExtension}");
-
             try
             {
-                File.Copy(sourcePath, fullDestinationPath, false);
+                byte[] staticSalt = Encoding.UTF8.GetBytes("PangoStaticExportSalt");
 
-                var newResult = new ExportResult(
-                    fullDestinationPath,
-                    result.Value.Contents,
-                    result.Value.GeneratedAt,
-                    result.Value.AppVersion
-                );
+                using var derive = new Rfc2898DeriveBytes(
+                    masterPassword,
+                    staticSalt,
+                    50000,
+                    HashAlgorithmName.SHA256);
 
-                WeakReferenceMessenger.Default.Send<ExportCompletedMessage>(new ExportCompletedMessage(newResult));
+                string keyBase64 = Convert.ToBase64String(derive.GetBytes(32));
+                string ivBase64 = Convert.ToBase64String(derive.GetBytes(16));
 
-                if (File.Exists(sourcePath))
+                var encoding = new EncodingOptions(keyBase64, ivBase64);
+
+                ErrorOr<ExportResult> result = await _sender.Send(new ExportDataCommand(
+                    itemsToExport,
+                    new ExportOptions(description, encoding)
+                ));
+
+                if (result.IsError)
                 {
-                    File.Delete(sourcePath);
+                    return (false, result.FirstError.Description, null);
+                }
+                else
+                {
+                    var sourcePath = result.Value.Path;
+                    string fullDestinationPath = Path.Combine(exportPath, $"{fileName}{FileExtension}");
+
+                    File.Copy(sourcePath, fullDestinationPath, true);
+                    if (File.Exists(sourcePath)) File.Delete(sourcePath);
+
+                    var finalResult = new ExportResult(fullDestinationPath, result.Value.Contents, result.Value.GeneratedAt, result.Value.AppVersion);
+                    return (true, string.Empty, finalResult);
                 }
             }
             catch (Exception ex)
             {
-                Logger.LogError(ex, "Failed to copy exported file to destination folder");
-                WeakReferenceMessenger.Default.Send(new InAppNotificationMessage($"Failed to save file to selected folder: {ex.Message}", Core.Enums.AppNotificationType.Error));
-                WeakReferenceMessenger.Default.Send<ExportCompletedMessage>(new ExportCompletedMessage(result.Value));
+                Logger.LogError(ex, "Export process failed");
+                return (false, ex.Message, null);
             }
+        });
+
+        if (exportResult.Success && exportResult.Result != null)
+        {
+            WeakReferenceMessenger.Default.Send(new ExportCompletedMessage(exportResult.Result));
+        }
+        else
+        {
+            WeakReferenceMessenger.Default.Send(new InAppNotificationMessage(
+                $"Export failed: {exportResult.ErrorMessage}",
+                Core.Enums.AppNotificationType.Error));
         }
     }
 

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Dialogs/ViewModels/ImportDialogViewModel.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Dialogs/ViewModels/ImportDialogViewModel.cs
@@ -11,13 +11,12 @@ using Pango.Desktop.Uwp.Mvvm.Models;
 using Pango.Desktop.Uwp.ViewModels;
 using Pango.Persistence.File;
 using System;
-using System.Text;
 using System.Threading.Tasks;
 using ImportDataValidator = Pango.Desktop.Uwp.Dialogs.Validators.ImportDataValidator;
 
 namespace Pango.Desktop.Uwp.Dialogs.ViewModels;
 
-public class ImportDialogViewModel : ViewModelBase, IDialogViewModel
+public partial class ImportDialogViewModel : ViewModelBase, IDialogViewModel
 {
     #region Fields
 
@@ -42,7 +41,7 @@ public class ImportDialogViewModel : ViewModelBase, IDialogViewModel
 
     public IDialogContext DialogContext { get; }
 
-    public ImportDataValidator Validator 
+    public ImportDataValidator Validator
     {
         get => _validator;
         set => SetProperty(ref _validator, value);
@@ -86,26 +85,28 @@ public class ImportDialogViewModel : ViewModelBase, IDialogViewModel
             return;
         }
 
-        byte[]? saltBytes = Encoding.UTF8.GetBytes(this.Validator.MasterPassword);
-        Array.Resize(ref saltBytes, 16);
-
-        string passwordHash = _passwordHashProvider.Hash(Validator.MasterPassword, saltBytes);
-        EncodingOptions encoding = new (passwordHash, Convert.ToBase64String(saltBytes));
+        string password = Validator.MasterPassword?.Trim() ?? string.Empty;
+        var encoding = new EncodingOptions(password, string.Empty);
 
         ErrorOr<ImportResult> result = await _sender.Send(new ImportDataCommand(_parameters.FilePath, new ImportOptions(encoding)));
 
         if (result.IsError)
         {
-            WeakReferenceMessenger.Default.Send(new InAppNotificationMessage($"Import failed: {result.FirstError}", Core.Enums.AppNotificationType.Error));
+            WeakReferenceMessenger.Default.Send(new InAppNotificationMessage(
+                ViewResourceLoader.GetString("Import_EncryptedArchiveError"), Core.Enums.AppNotificationType.Error));
         }
         else
         {
-            int count = result.Value.Manifest.Contents[Domain.Enums.ContentType.Passwords];
-            string message = count == 1 ? ViewResourceLoader.GetString("ImportSingleCompleted_Message")
-                : string.Format(ViewResourceLoader.GetString("ImportCompleted_Message"), count);
+            int count = 0;
+            if (result.Value.Manifest.Contents != null && result.Value.Manifest.Contents.TryGetValue(Domain.Enums.ContentType.Passwords, out int value))
+            {
+                count = value;
+            }
 
-            WeakReferenceMessenger.Default.Send<InAppNotificationMessage>(new InAppNotificationMessage(message));
-            WeakReferenceMessenger.Default.Send<ImportCompletedMessage>(new ImportCompletedMessage(result.Value));
+            string message = count == 1 ? ViewResourceLoader.GetString("ImportSingleCompleted_Message") : string.Format(ViewResourceLoader.GetString("ImportCompleted_Message"), count);
+
+            WeakReferenceMessenger.Default.Send(new InAppNotificationMessage(message));
+            WeakReferenceMessenger.Default.Send(new ImportCompletedMessage(result.Value));
         }
     }
 

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Dialogs/ViewModels/ImportDialogViewModel.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Dialogs/ViewModels/ImportDialogViewModel.cs
@@ -1,16 +1,15 @@
 ﻿using CommunityToolkit.Mvvm.Messaging;
-using ErrorOr;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using Pango.Application.Common;
 using Pango.Application.Common.Interfaces.Services;
-using Pango.Application.UseCases.Data.Commands.Import;
 using Pango.Desktop.Uwp.Dialogs.Parameters;
 using Pango.Desktop.Uwp.Mvvm.Messages;
 using Pango.Desktop.Uwp.Mvvm.Models;
 using Pango.Desktop.Uwp.ViewModels;
 using Pango.Persistence.File;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using ImportDataValidator = Pango.Desktop.Uwp.Dialogs.Validators.ImportDataValidator;
 
@@ -20,33 +19,26 @@ public partial class ImportDialogViewModel : ViewModelBase, IDialogViewModel
 {
     #region Fields
 
-    private readonly ISender _sender;
     private ImportDataValidator _validator;
     private ImportDataParameters? _parameters;
-    private readonly IPasswordHashProvider _passwordHashProvider;
+    private readonly IDataImporter _dataImporter;
 
     #endregion
 
-    public ImportDialogViewModel(ISender sender, IPasswordHashProvider passwordHashProvider, ILogger<ImportDialogViewModel> logger) : base(logger)
+    public ImportDialogViewModel(ISender sender, IDataImporter dataImporter, ILogger<ImportDialogViewModel> logger) : base(logger)
     {
         DialogContext = new DialogContext();
-
-        _sender = sender;
+        _dataImporter = dataImporter;
         _validator = new();
         _validator.ErrorsChanged += Validator_ErrorsChanged;
-        _passwordHashProvider = passwordHashProvider;
     }
 
     #region Properties
 
     public IDialogContext DialogContext { get; }
+    public ImportDataValidator Validator { get => _validator; set => SetProperty(ref _validator, value); }
 
-    public ImportDataValidator Validator
-    {
-        get => _validator;
-        set => SetProperty(ref _validator, value);
-    }
-
+    
     #endregion
 
     #region Overrides
@@ -54,59 +46,52 @@ public partial class ImportDialogViewModel : ViewModelBase, IDialogViewModel
     public override async Task OnNavigatedToAsync(object? parameter)
     {
         await base.OnNavigatedToAsync(parameter);
-
         ResetDialog();
-
-        if (parameter is ImportDataParameters dialogParameters)
-        {
-            _parameters = dialogParameters;
-        }
+        if (parameter is ImportDataParameters dialogParameters) _parameters = dialogParameters;
     }
 
     #endregion
 
     #region Public Methods
 
-    public bool CanSave()
-    {
-        return !Validator.HasErrors;
-    }
-
-    public Task OnCancelAsync()
-    {
-        return Task.CompletedTask;
-    }
+    public bool CanSave() => !Validator.HasErrors;
+    public Task OnCancelAsync() => Task.CompletedTask;
 
     public async Task OnSaveAsync()
     {
-        if (_parameters is null)
-        {
-            Logger.LogError("Cannot do the import: ImportDataParameters is null");
-            return;
-        }
+        if (_parameters is null) return;
 
         string password = Validator.MasterPassword?.Trim() ?? string.Empty;
         var encoding = new EncodingOptions(password, string.Empty);
 
-        ErrorOr<ImportResult> result = await _sender.Send(new ImportDataCommand(_parameters.FilePath, new ImportOptions(encoding)));
+        try
+        {
+            // Try to decrypt content to validate password and get items
+            var options = new ImportOptions(encoding);
+            var content = await _dataImporter.ExtractContentAsync(_parameters.FilePath, options);
 
-        if (result.IsError)
-        {
-            WeakReferenceMessenger.Default.Send(new InAppNotificationMessage(
-                ViewResourceLoader.GetString("Import_EncryptedArchiveError"), Core.Enums.AppNotificationType.Error));
-        }
-        else
-        {
-            int count = 0;
-            if (result.Value.Manifest.Contents != null && result.Value.Manifest.Contents.TryGetValue(Domain.Enums.ContentType.Passwords, out int value))
+            List<Domain.Entities.PangoPassword> allItems = [];
+            foreach (var package in content)
             {
-                count = value;
+                if (package.Data is IEnumerable<Domain.Entities.PangoPassword> items)
+                    allItems.AddRange(items);
             }
 
-            string message = count == 1 ? ViewResourceLoader.GetString("ImportSingleCompleted_Message") : string.Format(ViewResourceLoader.GetString("ImportCompleted_Message"), count);
+            // Create parameters with decrypted content and password
+            var selectiveParams = new ImportDataParametersWithPassword(_parameters.FilePath, password, allItems);
 
-            WeakReferenceMessenger.Default.Send(new InAppNotificationMessage(message));
-            WeakReferenceMessenger.Default.Send(new ImportCompletedMessage(result.Value));
+            // Request navigation to the Selection Dialog
+            WeakReferenceMessenger.Default.Send(new NavigationRequstedMessage(
+                new NavigationParameters(Core.Enums.AppView.ExportImport, Core.Enums.AppView.ExportImport, selectiveParams)
+            ));
+
+            // Notify UI to open the specific dialog
+            WeakReferenceMessenger.Default.Send(new ImportPreviewReadyMessage(selectiveParams));
+        }
+        catch (Exception)
+        {
+            WeakReferenceMessenger.Default.Send(new InAppNotificationMessage(
+               ViewResourceLoader.GetString("Import_EncryptedArchiveError"), Core.Enums.AppNotificationType.Error));
         }
     }
 
@@ -116,11 +101,7 @@ public partial class ImportDialogViewModel : ViewModelBase, IDialogViewModel
 
     private void ResetDialog()
     {
-        if (Validator != null)
-        {
-            Validator.ErrorsChanged -= Validator_ErrorsChanged;
-        }
-
+        if (Validator != null) Validator.ErrorsChanged -= Validator_ErrorsChanged;
         Validator = new();
         Validator.ErrorsChanged += Validator_ErrorsChanged;
 
@@ -128,10 +109,10 @@ public partial class ImportDialogViewModel : ViewModelBase, IDialogViewModel
         DialogContext.RaiseDialogContentChanged();
     }
 
-    private void Validator_ErrorsChanged(object? sender, System.ComponentModel.DataErrorsChangedEventArgs e)
-    {
-        DialogContext.RaiseDialogContentChanged(e);
-    }
-
+    private void Validator_ErrorsChanged(object? sender, System.ComponentModel.DataErrorsChangedEventArgs e) => DialogContext.RaiseDialogContentChanged(e);
+    
     #endregion
 }
+
+// Message to trigger the second dialog
+public class ImportPreviewReadyMessage(ImportDataParameters parameters) : CommunityToolkit.Mvvm.Messaging.Messages.ValueChangedMessage<ImportDataParameters>(parameters);

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Models/PangoExplorerItem.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Models/PangoExplorerItem.cs
@@ -1,14 +1,18 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Messaging;
 using Pango.Application.Common;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
 
 namespace Pango.Desktop.Uwp.Models;
 
+public class SelectionChangedMessage { }
+
 [DebuggerDisplay("{UniqueId}")]
-public class PangoExplorerItem : ObservableObject
+public partial class PangoExplorerItem : ObservableObject
 {
     public enum ExplorerItemType { Folder, File };
 
@@ -18,6 +22,7 @@ public class PangoExplorerItem : ObservableObject
     private string _catalogPath = string.Empty;
     private bool _isVisible = true;
     private bool _isSelected = false;
+    private bool _isSettingSelection = false;
 
     private ObservableCollection<PangoExplorerItem> _children = [];
 
@@ -43,7 +48,9 @@ public class PangoExplorerItem : ObservableObject
 
     public string Name { get; set; } = string.Empty;
 
-    public int NestingLevel { get; private set; } 
+    public bool IsFolder => Type == ExplorerItemType.Folder;
+
+    public int NestingLevel { get; private set; }
 
     public string CatalogPath
     {
@@ -74,7 +81,7 @@ public class PangoExplorerItem : ObservableObject
         set => SetProperty(ref _isExpanded, value);
     }
 
-    public bool IsVisible 
+    public bool IsVisible
     {
         get => _isVisible;
         set => SetProperty(ref _isVisible, value);
@@ -83,8 +90,75 @@ public class PangoExplorerItem : ObservableObject
     public bool IsSelected
     {
         get => _isSelected;
-        set => SetProperty(ref _isSelected, value);
+        set
+        {
+            if (_isSettingSelection) return;
+
+            _isSettingSelection = true;
+            try
+            {
+                if (SetProperty(ref _isSelected, value))
+                {
+                    if (IsFolder)
+                    {
+                        foreach (var child in Children)
+                        {
+                            child.IsSelected = value;
+                        }
+                    }
+
+                    if (value && Parent != null)
+                    {
+                        // Check if all siblings are selected to update parent state if needed (optional logic could go here)
+                        Parent.IsSelected = true;
+                    }
+
+                    WeakReferenceMessenger.Default.Send(new SelectionChangedMessage());
+                }
+            }
+            finally
+            {
+                _isSettingSelection = false;
+            }
+        }
     }
 
     #endregion
+
+    public void AddChild(PangoExplorerItem child)
+    {
+        // Prevent duplicates: do not add if child with same ID already exists
+        if (Children.Any(c => c.Id == child.Id)) return;
+
+        child.Parent = this;
+        Children.Add(child);
+    }
+
+    public IEnumerable<PangoExplorerItem> GetAllDescendants()
+    {
+        foreach (var child in Children)
+        {
+            yield return child;
+            foreach (var descendant in child.GetAllDescendants())
+            {
+                yield return descendant;
+            }
+        }
+    }
+
+    // Override Equals to ensure items with same ID are treated as one
+    public override bool Equals(object? obj)
+    {
+        if (obj is PangoExplorerItem item)
+        {
+            return Id == item.Id;
+        }
+        return false;
+    }
+
+    // Override GetHashCode to match Equals logic
+    public override int GetHashCode()
+    {
+        return Id.GetHashCode();
+    }
 }

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Strings/be-BY/Resources.resw
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Strings/be-BY/Resources.resw
@@ -541,4 +541,46 @@
   <data name="ValidationError_FileExists" xml:space="preserve">
     <value>Файл з такой назвай ужо існуе ў абранай папцы.</value>
   </data>
+  <data name="BackupSettings_Header" xml:space="preserve">
+    <value>Рэзервовае капіраванне</value>
+  </data>
+  <data name="BackupPath_Label" xml:space="preserve">
+    <value>Шлях захавання</value>
+  </data>
+  <data name="Browse_Button" xml:space="preserve">
+    <value>Агляд...</value>
+  </data>
+  <data name="DefaultPath_Button" xml:space="preserve">
+    <value>Шлях па змаўчанні</value>
+  </data>
+  <data name="OpenFolder_Button" xml:space="preserve">
+    <value>Адкрыць папку</value>
+  </data>
+  <data name="BackupInterval_Label" xml:space="preserve">
+    <value>Перыядычнасць</value>
+  </data>
+  <data name="Hour(-s)" xml:space="preserve">
+    <value>гадзін(-ы)</value>
+  </data>
+  <data name="BackupSaved_Message" xml:space="preserve">
+    <value>Налады бэкапу захаваны.</value>
+  </data>
+  <data name="BackupPathInvalid_Error" xml:space="preserve">
+    <value>Няправільны шлях.</value>
+  </data>
+  <data name="SaveChanges" xml:space="preserve">
+    <value>Захаваць змены</value>
+  </data>
+  <data name="BackupService_Toggle" xml:space="preserve">
+    <value>Уключыць фонавую службу бэкапу</value>
+  </data>
+  <data name="BackupPassword_Label" xml:space="preserve">
+    <value>Пароль рэзервовай копіі (аўтаматычны)</value>
+  </data>
+  <data name="BackupPassword_Tooltip" xml:space="preserve">
+    <value>Гэты пароль выкарыстоўваецца для шыфравання файлаў. Ён спатрэбіцца для аднаўлення.</value>
+  </data>
+  <data name="Import_EncryptedArchiveError" xml:space="preserve">
+    <value>Архіў зашыфраваны. Праверце правільнасць пароля.</value>
+  </data>
 </root>

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Strings/be-BY/Resources.resw
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Strings/be-BY/Resources.resw
@@ -583,4 +583,55 @@
   <data name="Import_EncryptedArchiveError" xml:space="preserve">
     <value>Архіў зашыфраваны. Праверце правільнасць пароля.</value>
   </data>
+  <data name="Theme_Default" xml:space="preserve">
+    <value>Як у сістэме</value>
+  </data>
+  <data name="Theme_Light" xml:space="preserve">
+    <value>Светлая</value>
+  </data>
+  <data name="Theme_Dark" xml:space="preserve">
+    <value>Цёмная</value>
+  </data>
+  <data name="BackupRetention_Label" xml:space="preserve">
+    <value>Захоўваць копіі</value>
+  </data>
+  <data name="Day(-s)" xml:space="preserve">
+    <value>дзён/дні</value>
+  </data>
+  <data name="BugRequest_Header" xml:space="preserve">
+    <value>Паведаміць пра памылку ці прапанаваць функцыю</value>
+  </data>
+  <data name="Copyright_Description" xml:space="preserve">
+    <value>© 2026 Cats Lab. Усе правы абаронены.</value>
+  </data>
+  <data name="ToggleSwitch_On" xml:space="preserve">
+    <value>Укл.</value>
+  </data>
+  <data name="ToggleSwitch_Off" xml:space="preserve">
+    <value>Выкл.</value>
+  </data>
+  <data name="BackupServiceDescription" xml:space="preserve">
+    <value>Аўтаматычна захоўваць зашыфраваныя копіі вашых даных</value>
+  </data>
+  <data name="ImportSettings_Header" xml:space="preserve">
+    <value>Імпарт</value>
+  </data>
+  <data name="ImportDestination_Label" xml:space="preserve">
+    <value>Месца прызначэння</value>
+  </data>
+  <data name="ImportDestination_Description" xml:space="preserve">
+    <value>Выберыце, куды будуць змешчаны імпартаваныя элементы</value>
+  </data>
+  <data name="ImportDestination_Root" xml:space="preserve">
+    <value>Імпартаваць у каранёвы каталог</value>
+  </data>
+  <data name="ImportDestination_Folder" xml:space="preserve">
+    <value>Імпартаваць у асобную папку</value>
+  </data>
+  <data name="SelectItemsToImport" xml:space="preserve">
+    <value>Выберыце элементы для імпарту</value>
+  </data>
+  <data name="ImportPreview_Loading" xml:space="preserve">
+    <value>Чытанне структуры файла...</value>
+  </data>
 </root>

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Strings/be-BY/Resources.resw
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Strings/be-BY/Resources.resw
@@ -726,7 +726,5 @@
   </data>
   <data name="ImportPreview_Loading" xml:space="preserve">
     <value>Чытанне структуры файла...</value>
-    <value>Захаваць як</value>
->>>>>>>>> Temporary merge branch 2
   </data>
 </root>

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Strings/en-US/Resources.resw
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Strings/en-US/Resources.resw
@@ -543,4 +543,46 @@
   <data name="ValidationError_FileExists" xml:space="preserve">
     <value>A file with this name already exists in the selected folder.</value>
   </data>
+  <data name="BackupSettings_Header" xml:space="preserve">
+    <value>Backup</value>
+  </data>
+  <data name="BackupPath_Label" xml:space="preserve">
+    <value>Storage Path</value>
+  </data>
+  <data name="Browse_Button" xml:space="preserve">
+    <value>Browse...</value>
+  </data>
+  <data name="DefaultPath_Button" xml:space="preserve">
+    <value>Default path</value>
+  </data>
+  <data name="OpenFolder_Button" xml:space="preserve">
+    <value>Open folder</value>
+  </data>
+  <data name="BackupInterval_Label" xml:space="preserve">
+    <value>Frequency</value>
+  </data>
+  <data name="Hour(-s)" xml:space="preserve">
+    <value>hour(s)</value>
+  </data>
+  <data name="BackupSaved_Message" xml:space="preserve">
+    <value>Backup settings saved.</value>
+  </data>
+  <data name="BackupPathInvalid_Error" xml:space="preserve">
+    <value>Invalid path.</value>
+  </data>
+  <data name="SaveChanges" xml:space="preserve">
+    <value>Save Changes</value>
+  </data>
+  <data name="BackupService_Toggle" xml:space="preserve">
+    <value>Enable Background Backup Service</value>
+  </data>
+  <data name="BackupPassword_Label" xml:space="preserve">
+    <value>Backup Password (Auto-generated)</value>
+  </data>
+  <data name="BackupPassword_Tooltip" xml:space="preserve">
+    <value>This password is used to encrypt your backup files. You will need it to import/restore data.</value>
+  </data>
+  <data name="Import_EncryptedArchiveError" xml:space="preserve">
+    <value>The archive is encrypted. Please ensure you entered the correct backup password.</value>
+  </data>
 </root>

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Strings/en-US/Resources.resw
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Strings/en-US/Resources.resw
@@ -585,4 +585,55 @@
   <data name="Import_EncryptedArchiveError" xml:space="preserve">
     <value>The archive is encrypted. Please ensure you entered the correct backup password.</value>
   </data>
+  <data name="Theme_Default" xml:space="preserve">
+    <value>System Default</value>
+  </data>
+  <data name="Theme_Light" xml:space="preserve">
+    <value>Light</value>
+  </data>
+  <data name="Theme_Dark" xml:space="preserve">
+    <value>Dark</value>
+  </data>
+  <data name="BackupRetention_Label" xml:space="preserve">
+    <value>Keep backups for</value>
+  </data>
+  <data name="Day(-s)" xml:space="preserve">
+    <value>day(s)</value>
+  </data>
+  <data name="BugRequest_Header" xml:space="preserve">
+    <value>File a bug or request new feature</value>
+  </data>
+  <data name="Copyright_Description" xml:space="preserve">
+    <value>© 2026 Cats Lab. All rights reserved.</value>
+  </data>
+  <data name="ToggleSwitch_On" xml:space="preserve">
+    <value>On</value>
+  </data>
+  <data name="ToggleSwitch_Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="BackupServiceDescription" xml:space="preserve">
+    <value>Automatically save encrypted copies of your data</value>
+  </data>
+  <data name="ImportSettings_Header" xml:space="preserve">
+    <value>Import</value>
+  </data>
+  <data name="ImportDestination_Label" xml:space="preserve">
+    <value>Destination</value>
+  </data>
+  <data name="ImportDestination_Description" xml:space="preserve">
+    <value>Choose where imported items will be placed</value>
+  </data>
+  <data name="ImportDestination_Root" xml:space="preserve">
+    <value>Import into root directory</value>
+  </data>
+  <data name="ImportDestination_Folder" xml:space="preserve">
+    <value>Import into separate folder</value>
+  </data>
+  <data name="SelectItemsToImport" xml:space="preserve">
+    <value>Select items to import</value>
+  </data>
+  <data name="ImportPreview_Loading" xml:space="preserve">
+    <value>Reading file structure...</value>
+  </data>
 </root>

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Strings/en-US/Resources.resw
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Strings/en-US/Resources.resw
@@ -728,12 +728,5 @@
   </data>
   <data name="ImportPreview_Loading" xml:space="preserve">
     <value>Reading file structure...</value>
-=========
-  <data name="PasswordGeneratedSuccessfully" xml:space="preserve">
-    <value>Password generated successfully</value>
-  </data>
-  <data name="SaveAs" xml:space="preserve">
-    <value>Save as</value>
->>>>>>>>> Temporary merge branch 2
   </data>
 </root>

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/ExportImportViewModel.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/ExportImportViewModel.cs
@@ -4,27 +4,32 @@ using ErrorOr;
 using Mapster;
 using MediatR;
 using Microsoft.Extensions.Logging;
+using Pango.Application.Common;
 using Pango.Application.Common.Interfaces.Services;
 using Pango.Application.Models;
 using Pango.Application.UseCases.Data.Commands.Export;
+using Pango.Application.UseCases.Data.Commands.Import;
 using Pango.Application.UseCases.Password.Queries.UserPasswords;
 using Pango.Desktop.Uwp.Core.Attributes;
 using Pango.Desktop.Uwp.Core.Enums;
 using Pango.Desktop.Uwp.Core.Extensions;
+using Pango.Desktop.Uwp.Core.Utility;
 using Pango.Desktop.Uwp.Dialogs;
 using Pango.Desktop.Uwp.Dialogs.Parameters;
 using Pango.Desktop.Uwp.Models;
 using Pango.Desktop.Uwp.Mvvm.Messages;
+using Pango.Desktop.Uwp.Mvvm.Models;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
+using Windows.Storage;
 
 namespace Pango.Desktop.Uwp.ViewModels;
 
 [AppView(AppView.ExportImport)]
-public sealed class ExportImportViewModel : ViewModelBase
+public sealed partial class ExportImportViewModel : ViewModelBase
 {
     #region Fields
 
@@ -34,25 +39,29 @@ public sealed class ExportImportViewModel : ViewModelBase
     private int _selectedOption;
     private string _titleText = string.Empty;
     private string _importFilePath = string.Empty;
+    private string _decryptedPasswordCache = string.Empty;
 
     #endregion
 
     public ExportImportViewModel(
-        ILogger<ExportImportViewModel> logger, 
-        ISender sender, 
-        IUserContextProvider userContextProvider, 
-        IDialogService dialogService) 
+        ILogger<ExportImportViewModel> logger,
+        ISender sender,
+        IUserContextProvider userContextProvider,
+        IDialogService dialogService)
         : base(logger)
     {
         ExportDataCommand = new RelayCommand(OnExportAsync, CanExport);
-        ImportDataCommand = new RelayCommand(OnImportDataAsync, CanImport);
-        NavigateToOptionCommand = new RelayCommand<int>(async(e) => await OnNavigateToOptionAsync(e));
+        ReadImportFileCommand = new RelayCommand(OnReadImportFileAsync, CanReadImportFile); // Step 1
+        FinalizeImportCommand = new RelayCommand(OnFinalizeImportAsync, CanFinalizeImport); // Step 3
+        NavigateToOptionCommand = new RelayCommand<int>(async (e) => await OnNavigateToOptionAsync(e));
 
         _sender = sender;
         _userContextProvider = userContextProvider;
         _dialogService = dialogService;
 
-        Passwords = [];
+        Passwords = []; // Export Tree Items
+        ImportItems = []; // Import Tree Items
+
         TitleText = ViewResourceLoader.GetString("ExportAndImportTooltip");
     }
 
@@ -60,7 +69,13 @@ public sealed class ExportImportViewModel : ViewModelBase
     #region Commands
 
     public RelayCommand ExportDataCommand { get; }
-    public RelayCommand ImportDataCommand { get; }
+
+    // Step 1: Open Password Dialog
+    public RelayCommand ReadImportFileCommand { get; }
+
+    // Step 3: Execute Import
+    public RelayCommand FinalizeImportCommand { get; }
+
     public RelayCommand<int> NavigateToOptionCommand { get; }
 
     #endregion
@@ -68,6 +83,9 @@ public sealed class ExportImportViewModel : ViewModelBase
     #region Properties
 
     public ObservableCollection<PangoExplorerItem> Passwords { get; private set; }
+
+    // Collection for the Import TreeView (Pivot Item 3)
+    public ObservableCollection<PangoExplorerItem> ImportItems { get; private set; }
 
     /// <summary>
     /// Path to the pango archive that's gonna be imported
@@ -78,7 +96,8 @@ public sealed class ExportImportViewModel : ViewModelBase
         set
         {
             SetProperty(ref _importFilePath, value);
-            OnPropertyChanged(nameof(ImportDataCommand));
+            OnPropertyChanged(nameof(ReadImportFileCommand));
+            ReadImportFileCommand.NotifyCanExecuteChanged();
         }
     }
 
@@ -92,21 +111,23 @@ public sealed class ExportImportViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Selected view tab: general, import or export
+    /// Selected view tab: 0-general, 1-export, 2-import file, 3-import selection
     /// </summary>
     public int SelectedOption
     {
         get => _selectedOption;
-        set 
+        set
         {
-            SetProperty(ref _selectedOption, value);
-
-            TitleText = value switch
+            if (SetProperty(ref _selectedOption, value))
             {
-                1 => ViewResourceLoader.GetString("ExportTitle"),
-                2 => ViewResourceLoader.GetString("ImportTitle"),
-                _ => ViewResourceLoader.GetString("ExportAndImportTooltip")
-            };
+                TitleText = value switch
+                {
+                    1 => ViewResourceLoader.GetString("ExportTitle"),
+                    2 => ViewResourceLoader.GetString("ImportTitle"),
+                    3 => ViewResourceLoader.GetString("SelectItemsToImport"),
+                    _ => ViewResourceLoader.GetString("ExportAndImportTooltip")
+                };
+            }
         }
     }
 
@@ -117,7 +138,6 @@ public sealed class ExportImportViewModel : ViewModelBase
     public override async Task OnNavigatedToAsync(object? parameter)
     {
         await base.OnNavigatedToAsync(parameter);
-
         await ResetViewAsync();
     }
 
@@ -126,6 +146,14 @@ public sealed class ExportImportViewModel : ViewModelBase
         base.RegisterMessages();
         WeakReferenceMessenger.Default.Register<ExportCompletedMessage>(this, OnExportCompleted);
         WeakReferenceMessenger.Default.Register<ImportCompletedMessage>(this, OnImportCompleted);
+        WeakReferenceMessenger.Default.Register<SelectionChangedMessage>(this, (r, m) =>
+        {
+            App.Current.CurrentWindow?.DispatcherQueue.TryEnqueue(() =>
+            {
+                ExportDataCommand.NotifyCanExecuteChanged();
+                FinalizeImportCommand.NotifyCanExecuteChanged();
+            });
+        });
     }
 
     protected override void UnregisterMessages()
@@ -133,21 +161,16 @@ public sealed class ExportImportViewModel : ViewModelBase
         base.UnregisterMessages();
         WeakReferenceMessenger.Default.Unregister<ExportCompletedMessage>(this);
         WeakReferenceMessenger.Default.Unregister<ImportCompletedMessage>(this);
+        WeakReferenceMessenger.Default.Unregister<SelectionChangedMessage>(this);
     }
 
     #endregion
 
     #region Private Methods
 
-    private bool CanExport()
-    {
-        return Passwords.Any(p => p.IsSelected);
-    }
-
-    private bool CanImport()
-    {
-        return !string.IsNullOrWhiteSpace(ImportFilePath);
-    }
+    private bool CanExport() => Passwords.Any(p => p.IsSelected);
+    private bool CanReadImportFile() => !string.IsNullOrWhiteSpace(ImportFilePath);
+    private bool CanFinalizeImport() => ImportItems.FindItems(x => x.IsSelected).Count != 0;
 
     private async void OnImportCompleted(object recipient, ImportCompletedMessage message)
     {
@@ -167,73 +190,108 @@ public sealed class ExportImportViewModel : ViewModelBase
     private async Task ResetViewAsync()
     {
         await OnNavigateToOptionAsync(0);
-        IEnumerable<PangoExplorerItem> passwords = await LoadPasswordsAsync();
+        _decryptedPasswordCache = string.Empty;
+        ImportItems.Clear();
+        ImportFilePath = string.Empty;
+
+        // Reload export data in background to keep UI fresh
+        var passwords = await LoadPasswordsAsync();
         DisplayPasswordsInTree(passwords);
     }
 
-    /// <summary>
-    /// Opens a dialog to import items from selected archive, located at <see cref="ImportFilePath"/>
-    /// </summary>
-    private async void OnImportDataAsync()
+    // Step 1: Open Password Dialog
+    private async void OnReadImportFileAsync()
     {
         await _dialogService.ShowDataImportDialogAsync(new ImportDataParameters(ImportFilePath));
     }
 
-    /// <summary>
-    /// Opens a dialog to export selected items
-    /// </summary>
+    // Step 2: Called by View when password is correct (via Messenger)
+    public async Task HandleImportPreviewAsync(ImportDataParameters parameters)
+    {
+        if (parameters is ImportDataParametersWithPassword p)
+        {
+            _decryptedPasswordCache = p.Password;
+
+            ImportItems.Clear();
+
+            // Build tree from the decrypted content passed from dialog
+            var tree = TreeBuilder.BuildTree([.. p.PreLoadedContent]);
+            foreach (var item in tree)
+            {
+                ImportItems.Add(item);
+            }
+
+            // Move to Selection Tab
+            await OnNavigateToOptionAsync(3);
+        }
+    }
+
+    // Step 3: Execute Import
+    private async void OnFinalizeImportAsync()
+    {
+        IsBusy = true;
+        try
+        {
+            var selectedIds = ImportItems.FindItems(x => x.IsSelected).Select(x => x.Id).ToList();
+
+            // Read Import Destination Setting
+            bool importToFolder = false;
+            if (ApplicationData.Current.LocalSettings.Values.TryGetValue("ImportDestination", out object? val))
+            {
+                if (val is int i) importToFolder = i == 1;
+                else if (val is bool b) importToFolder = b;
+            }
+
+            var encoding = new EncodingOptions(_decryptedPasswordCache, "");
+            var options = new Pango.Persistence.File.ImportOptions(encoding);
+
+            var cmd = new ImportDataCommand(ImportFilePath, options, selectedIds, importToFolder);
+            var result = await _sender.Send(cmd);
+
+            if (result.IsError)
+            {
+                WeakReferenceMessenger.Default.Send(new InAppNotificationMessage(result.FirstError.Description, Core.Enums.AppNotificationType.Error));
+            }
+            else
+            {
+                WeakReferenceMessenger.Default.Send(new InAppNotificationMessage(ViewResourceLoader.GetString("ImportCompleted_Message")));
+                WeakReferenceMessenger.Default.Send(new ImportCompletedMessage(result.Value));
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Import finalization failed");
+            WeakReferenceMessenger.Default.Send(new InAppNotificationMessage("Import failed", Core.Enums.AppNotificationType.Error));
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
     private async void OnExportAsync()
     {
         await _dialogService.ShowDataExportDialogAsync(new ExportDataParameters(PrepareContent()));
     }
 
-    /// <summary>
-    /// Converts all selected <see cref="PangoExplorerItem"/> from <see cref="Passwords"/> into a list of <see cref="ExportItem"/>
-    /// </summary>
-    /// <returns></returns>
     private List<ExportItem> PrepareContent()
     {
         var selected = FindAll([.. Passwords], p => p.IsSelected || p.Children.Any(c => c.IsSelected));
-        if(selected.Count == 0)
-        {
-            return [];
-        }
-
-        List<ExportItem> items = selected.Select(s => new ExportItem(Domain.Enums.ContentType.Passwords, s.Id)).ToList();
-
-        return items;
+        if (selected.Count == 0) return [];
+        return [.. selected.Select(s => new ExportItem(Domain.Enums.ContentType.Passwords, s.Id))];
     }
 
-    /// <summary>
-    /// Finds all <see cref="PangoExplorerItem"/> in <paramref name="sourceList"/> that fit <paramref name="predicate"/>
-    /// </summary>
-    /// <param name="sourceList"></param>
-    /// <param name="predicate"></param>
-    /// <returns></returns>
-    private List<PangoExplorerItem> FindAll(List<PangoExplorerItem> sourceList, Func<PangoExplorerItem, bool> predicate)
+    private static List<PangoExplorerItem> FindAll(List<PangoExplorerItem> sourceList, Func<PangoExplorerItem, bool> predicate)
     {
         List<PangoExplorerItem> result = [];
-
-        if (sourceList is null || sourceList.Count == 0)
-        {
-            return result;
-        }
+        if (sourceList is null || sourceList.Count == 0) return result;
 
         foreach (var item in sourceList)
         {
-            if (predicate(item))
-            {
-                result.Add(item);
-            }
-
+            if (predicate(item)) result.Add(item);
             var children = FindAll([.. item.Children], predicate);
-
-            if(children.Count > 0)
-            {
-                result.AddRange(children);
-            }
+            if (children.Count > 0) result.AddRange(children);
         }
-
         return result;
     }
 
@@ -244,23 +302,21 @@ public sealed class ExportImportViewModel : ViewModelBase
     /// <returns></returns>
     private async Task OnNavigateToOptionAsync(int option)
     {
-        switch(option)
+        SelectedOption = option;
+
+        switch (option)
         {
-            case 0:
-                SelectedOption = 0;
+            case 0: // General Menu
                 await OnNavigatedToGeneralAsync();
                 break;
-
-            case 1:
-                SelectedOption = 1;
+            case 1: // Export
                 await OnNavigatedToExportAsync();
                 break;
-
-            case 2:
-                SelectedOption = 2;
+            case 2: // Import File
                 await OnNavigatedToImportAsync();
                 break;
-            default:
+            case 3: // Import Selection
+                // Data is already loaded by HandleImportPreviewAsync
                 break;
         }
     }
@@ -306,7 +362,7 @@ public sealed class ExportImportViewModel : ViewModelBase
     /// <param name="password"></param>
     /// <param name="catalogs"></param>
     /// <returns></returns>
-    private bool AddPassword(ObservableCollection<PangoExplorerItem> passwords, PangoExplorerItem password, Queue<string>? catalogs)
+    private static bool AddPassword(ObservableCollection<PangoExplorerItem> passwords, PangoExplorerItem password, Queue<string>? catalogs)
     {
         if (catalogs is null || catalogs.Count == 0)
         {
@@ -317,12 +373,9 @@ public sealed class ExportImportViewModel : ViewModelBase
         string catalogName = catalogs.Dequeue();
         PangoExplorerItem? catalog = passwords.FirstOrDefault(p => p.Type == PangoExplorerItem.ExplorerItemType.Folder && p.Name == catalogName);
 
-        if (catalog is null)
-        {
-            return false;
-        }
+        if (catalog is null) return false;
 
-        if (catalogs.Any())
+        if (catalogs.Count != 0)
         {
             return AddPassword(catalog.Children, password, catalogs);
         }
@@ -353,28 +406,15 @@ public sealed class ExportImportViewModel : ViewModelBase
         {
             for (; index < sortedPasswordsList.Count; index++)
             {
-                if (sortedPasswordsList[index].Type == PangoExplorerItem.ExplorerItemType.File)
-                {
-                    break;
-                }
+                if (sortedPasswordsList[index].Type == PangoExplorerItem.ExplorerItemType.File) break;
             }
         }
 
         for (; index < sortedPasswordsList.Count; index++)
         {
-            if (sortedPasswordsList[index].Type == PangoExplorerItem.ExplorerItemType.File && passwordToInsert.Type == PangoExplorerItem.ExplorerItemType.Folder)
-            {
-                break;
-            }
-
-            if (sortedPasswordsList[index].Name.CompareTo(passwordToInsert.Name) < 0)
-            {
-                continue;
-            }
-            else
-            {
-                break;
-            }
+            if (sortedPasswordsList[index].Type == PangoExplorerItem.ExplorerItemType.File && passwordToInsert.Type == PangoExplorerItem.ExplorerItemType.Folder) break;
+            if (sortedPasswordsList[index].Name.CompareTo(passwordToInsert.Name) < 0) continue;
+            else break;
         }
 
         sortedPasswordsList.Insert(index, passwordToInsert);
@@ -382,6 +422,8 @@ public sealed class ExportImportViewModel : ViewModelBase
 
     private Task OnNavigatedToGeneralAsync()
     {
+        ImportFilePath = string.Empty;
+        ImportItems.Clear();
         return Task.CompletedTask;
     }
 
@@ -394,8 +436,9 @@ public sealed class ExportImportViewModel : ViewModelBase
     private Task OnNavigatedToImportAsync()
     {
         ImportFilePath = string.Empty;
-
+        ImportItems.Clear();
         return Task.CompletedTask;
     }
+
     #endregion
 }

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/SettingsViewModel.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/SettingsViewModel.cs
@@ -20,6 +20,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Windows.ApplicationModel.Resources;
 using Windows.Storage;
 using Windows.Storage.Pickers;
 using Windows.System;
@@ -29,22 +30,39 @@ namespace Pango.Desktop.Uwp.ViewModels;
 [AppView(AppView.Settings)]
 public partial class SettingsViewModel : ViewModelBase
 {
+    #region Nested Types
+
+    public enum ImportDestination { Root = 0, Folder = 1 }
+
+    public class ImportDestinationOption
+    {
+        public required string Content { get; set; }
+        public ImportDestination Value { get; set; }
+    }
+
+    #endregion
+
     #region Fields
 
     // Services
     private readonly IUserContextProvider _userContextProvider;
     private readonly IAppDomainProvider _appDomainProvider;
+    private readonly IAppMetaService _appMetaService;
+    private readonly ResourceLoader _resourceLoader;
 
     // Appearance & Behavior
     private AppLanguage _selectedLanguage;
     private AppTheme _selectedAppTheme;
     private bool _allowAutolock;
     private KeyValuePair<int, string>? _selectedLockOnIdleInMinutesItem;
+    private ImportDestination _selectedImportDestination;
+    private ObservableCollection<ImportDestinationOption> _importDestinationOptions = [];
 
     // Backup Configuration
     private string _configPath = string.Empty;
     private string _backupPath = string.Empty;
     private int _selectedBackupInterval;
+    private int _retentionDays;
     private bool _isBackupServiceEnabled;
     private string _backupPassword = string.Empty;
 
@@ -55,36 +73,35 @@ public partial class SettingsViewModel : ViewModelBase
     public SettingsViewModel(
         ILogger<SettingsViewModel> logger,
         IUserContextProvider userContextProvider,
-        IAppDomainProvider appDomainProvider) : base(logger)
+        IAppDomainProvider appDomainProvider,
+        IAppMetaService appMetaService) : base(logger)
     {
         _userContextProvider = userContextProvider;
         _appDomainProvider = appDomainProvider;
+        _appMetaService = appMetaService;
+        _resourceLoader = new ResourceLoader();
 
-        // 1. Initialize Collections
         Languages = new ObservableCollection<AppLanguage>(AppLanguage.GetAppLanguageCollection());
-        AppThemes = new ObservableCollection<AppTheme>(Enum.GetValues(typeof(ElementTheme))
-            .Cast<ElementTheme>()
-            .Select(e => new AppTheme { Name = ViewResourceLoader.GetString($"AppTheme_{e}"), Value = (int)e }));
+        AppThemes = [];
+        LockOnIdleInMinutesItems = [];
+        BackupIntervals = [5, 10, 15, 20, 30, 60, 120, 180];
 
-        string localizedMinutes = ViewResourceLoader.GetString("Minute(-s)");
-        LockOnIdleInMinutesItems = new ObservableCollection<KeyValuePair<int, string>>(
+        ImportDestinationOptions =
         [
-            new(1, $"1 {localizedMinutes}"),
-            new(3, $"3 {localizedMinutes}"),
-            new(5, $"5 {localizedMinutes}"),
-            new(10, $"10 {localizedMinutes}"),
-            new(15, $"15 {localizedMinutes}"),
-            new(30, $"30 {localizedMinutes}")
-        ]);
+            new() { Content = _resourceLoader.GetString("ImportDestination_Root"), Value = ImportDestination.Root },
+            new() { Content = _resourceLoader.GetString("ImportDestination_Folder"), Value = ImportDestination.Folder }
+        ];
 
-        BackupIntervals = new ObservableCollection<int>([1, 5, 10, 15, 20, 30, 45, 60]);
+        _selectedImportDestination = LoadImportSetting();
 
-        // 2. Initialize App Settings (Language/Theme)
+        InitializeDisplayResources();
+
         string appliedLocale = AppLanguageHelper.GetAppliedAppLanguage().Locale;
         _selectedLanguage = Languages.FirstOrDefault(e => e.Locale == appliedLocale) ?? Languages.First();
-        _selectedAppTheme = AppThemes.First(e => e.Value == (int)AppThemeHelper.Theme);
 
-        // 3. Initialize Autolock Settings
+        var currentThemeVal = (int)AppThemeHelper.Theme;
+        _selectedAppTheme = AppThemes.FirstOrDefault(e => e.Value == currentThemeVal) ?? AppThemes.First();
+
         int? blockAppAfterIdleMinutes = (int?)ApplicationData.Current.LocalSettings.Values[Constants.Settings.BlockAppAfterIdleMinutes];
         if (blockAppAfterIdleMinutes.HasValue)
         {
@@ -97,7 +114,6 @@ public partial class SettingsViewModel : ViewModelBase
             _allowAutolock = false;
         }
 
-        // 4. Initialize Backup Configuration
         _ = InitializeBackupConfigAsync();
     }
 
@@ -105,14 +121,7 @@ public partial class SettingsViewModel : ViewModelBase
 
     #region Properties - General
 
-    public static string Version
-    {
-        get
-        {
-            var version = System.Reflection.Assembly.GetEntryAssembly()?.GetName().Version;
-            return version is null ? "undefined" : string.Format("{0}.{1}.{2}.{3}", version.Major, version.Minor, version.Build, version.Revision);
-        }
-    }
+    public string Version => _appMetaService.GetAppVersion();
 
     #endregion
 
@@ -125,10 +134,10 @@ public partial class SettingsViewModel : ViewModelBase
         get => _selectedLanguage;
         set
         {
-            if (value is not null)
+            if (value is not null && SetProperty(ref _selectedLanguage, value))
             {
                 AppLanguageHelper.ChangeAppLanguage(value, typeof(SettingsView));
-                SetProperty(ref _selectedLanguage, value);
+                InitializeDisplayResources();
             }
         }
     }
@@ -140,14 +149,9 @@ public partial class SettingsViewModel : ViewModelBase
         get => _selectedAppTheme;
         set
         {
-            if (value != null)
+            if (value != null && SetProperty(ref _selectedAppTheme, value))
             {
-                ElementTheme? elementTheme = (ElementTheme)value.Value;
-                if (elementTheme.HasValue && elementTheme.Value != AppThemeHelper.Theme)
-                {
-                    AppThemeHelper.SetTheme(elementTheme.Value);
-                }
-                SetProperty(ref _selectedAppTheme, value);
+                AppThemeHelper.SetTheme((ElementTheme)value.Value);
             }
         }
     }
@@ -174,10 +178,18 @@ public partial class SettingsViewModel : ViewModelBase
         get => _allowAutolock;
         set
         {
-            SelectedLockOnIdleInMinutesItem = value ? LockOnIdleInMinutesItems[3] : null;
-            SetProperty(ref _allowAutolock, value);
+            if (SetProperty(ref _allowAutolock, value))
+            {
+                if (value && SelectedLockOnIdleInMinutesItem == null && LockOnIdleInMinutesItems.Count > 2)
+                    SelectedLockOnIdleInMinutesItem = LockOnIdleInMinutesItems[2];
+
+                if (!value)
+                    SelectedLockOnIdleInMinutesItem = null;
+            }
         }
     }
+
+    public bool AllowLaunchAtStartup { get => false; set { OnPropertyChanged(); } }
 
     #endregion
 
@@ -197,6 +209,17 @@ public partial class SettingsViewModel : ViewModelBase
         set => SetProperty(ref _selectedBackupInterval, value);
     }
 
+    public int RetentionDays
+    {
+        get => _retentionDays;
+        set
+        {
+            if (value < 1) value = 1;
+            if (value > 365) value = 365;
+            SetProperty(ref _retentionDays, value);
+        }
+    }
+
     public bool IsBackupServiceEnabled
     {
         get => _isBackupServiceEnabled;
@@ -207,6 +230,24 @@ public partial class SettingsViewModel : ViewModelBase
     {
         get => _backupPassword;
         set => SetProperty(ref _backupPassword, value);
+    }
+
+    public ObservableCollection<ImportDestinationOption> ImportDestinationOptions
+    {
+        get => _importDestinationOptions;
+        private set => SetProperty(ref _importDestinationOptions, value);
+    }
+
+    public ImportDestinationOption? SelectedImportDestination
+    {
+        get => ImportDestinationOptions.FirstOrDefault(x => x.Value == _selectedImportDestination);
+        set
+        {
+            if (value != null && SetProperty(ref _selectedImportDestination, value.Value))
+            {
+                SaveImportSetting(value.Value);
+            }
+        }
     }
 
     #endregion
@@ -228,23 +269,65 @@ public partial class SettingsViewModel : ViewModelBase
     private RelayCommand? _cancelBackupChangesCommand;
     public RelayCommand CancelBackupChangesCommand => _cancelBackupChangesCommand ??= new RelayCommand(async () => await LoadBackupSettingsAsync());
 
+    public void BugRequestCard_Click(object _, RoutedEventArgs _1)
+    {
+        _ = Launcher.LaunchUriAsync(new Uri("https://github.com/"));
+    }
+
     #endregion
 
     #region Methods - Backup Implementation
+
+    private void InitializeDisplayResources()
+    {
+        // 1. Refresh Themes
+        var currentThemeVal = _selectedAppTheme?.Value ?? (int)AppThemeHelper.Theme;
+
+        AppThemes.Clear();
+        AppThemes.Add(new AppTheme { Value = (int)ElementTheme.Default, Name = _resourceLoader.GetString("Theme_Default") });
+        AppThemes.Add(new AppTheme { Value = (int)ElementTheme.Light, Name = _resourceLoader.GetString("Theme_Light") });
+        AppThemes.Add(new AppTheme { Value = (int)ElementTheme.Dark, Name = _resourceLoader.GetString("Theme_Dark") });
+
+        _selectedAppTheme = AppThemes.FirstOrDefault(t => t.Value == currentThemeVal) ?? AppThemes.First();
+        OnPropertyChanged(nameof(SelectedAppTheme));
+
+        // 2. Refresh Autolock Options
+        string localizedMinutes = _resourceLoader.GetString("Minute(-s)");
+        var currentIdleKey = _selectedLockOnIdleInMinutesItem?.Key;
+
+        LockOnIdleInMinutesItems.Clear();
+        LockOnIdleInMinutesItems.Add(new(1, $"1 {localizedMinutes}"));
+        LockOnIdleInMinutesItems.Add(new(3, $"3 {localizedMinutes}"));
+        LockOnIdleInMinutesItems.Add(new(5, $"5 {localizedMinutes}"));
+        LockOnIdleInMinutesItems.Add(new(10, $"10 {localizedMinutes}"));
+        LockOnIdleInMinutesItems.Add(new(15, $"15 {localizedMinutes}"));
+        LockOnIdleInMinutesItems.Add(new(30, $"30 {localizedMinutes}"));
+
+        if (currentIdleKey.HasValue)
+        {
+            _selectedLockOnIdleInMinutesItem = LockOnIdleInMinutesItems.FirstOrDefault(k => k.Key == currentIdleKey);
+        }
+        OnPropertyChanged(nameof(SelectedLockOnIdleInMinutesItem));
+
+        // 3. Refresh Import Options
+        var currentImportVal = _selectedImportDestination;
+
+        ImportDestinationOptions.Clear();
+        ImportDestinationOptions.Add(new() { Content = _resourceLoader.GetString("ImportDestination_Root"), Value = ImportDestination.Root });
+        ImportDestinationOptions.Add(new() { Content = _resourceLoader.GetString("ImportDestination_Folder"), Value = ImportDestination.Folder });
+
+        // Restore selected item based on saved Value
+        OnPropertyChanged(nameof(SelectedImportDestination));
+    }
 
     private async Task InitializeBackupConfigAsync()
     {
         // Path to ProgramData/Pango/backup_config.json
         string commonAppData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
         string configDir = Path.Combine(commonAppData, "Pango");
-
-        if (!Directory.Exists(configDir))
-        {
-            Directory.CreateDirectory(configDir);
-        }
+        if (!Directory.Exists(configDir)) Directory.CreateDirectory(configDir);
 
         _configPath = Path.Combine(configDir, "backup_config.json");
-
         await LoadBackupSettingsAsync();
     }
 
@@ -253,7 +336,6 @@ public partial class SettingsViewModel : ViewModelBase
         try
         {
             BackupSettings? settings = null;
-
             if (File.Exists(_configPath))
             {
                 string json = await File.ReadAllTextAsync(_configPath);
@@ -266,9 +348,9 @@ public partial class SettingsViewModel : ViewModelBase
             BackupPath = string.IsNullOrEmpty(settings.TargetFolderPath) ? GetDefaultPath() : settings.TargetFolderPath;
             SelectedBackupInterval = settings.IntervalMinutes > 0 ? settings.IntervalMinutes : 60;
             IsBackupServiceEnabled = settings.IsEnabled;
+            RetentionDays = settings.RetentionDays > 0 ? settings.RetentionDays : 7;
 
             string currentUser = _userContextProvider.GetUserName();
-            bool needToSaveImmediately = false;
 
             if (settings.Users.TryGetValue(currentUser, out UserBackupProfile? profile))
             {
@@ -277,21 +359,6 @@ public partial class SettingsViewModel : ViewModelBase
             else
             {
                 BackupPassword = GenerateRandomPassword();
-
-                string sourcePath = _appDomainProvider.GetUserFolderPath(currentUser);
-
-                settings.Users.Add(currentUser, new UserBackupProfile
-                {
-                    BackupPassword = BackupPassword,
-                    SourceDataPath = sourcePath
-                });
-
-                needToSaveImmediately = true;
-            }
-
-            if (needToSaveImmediately)
-            {
-                await SaveSettingsToFileAsync(settings);
             }
         }
         catch (Exception ex)
@@ -299,6 +366,7 @@ public partial class SettingsViewModel : ViewModelBase
             Logger.LogError(ex, "Error loading backup settings");
             SetDefaultBackupPath();
             BackupPassword = GenerateRandomPassword();
+            RetentionDays = 7;
         }
     }
 
@@ -308,10 +376,7 @@ public partial class SettingsViewModel : ViewModelBase
         await File.WriteAllTextAsync(_configPath, json);
     }
 
-    private static string GetDefaultPath()
-    {
-        return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Pango", "Backup");
-    }
+    private static string GetDefaultPath() => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Pango", "Backup");
 
     private async Task BrowseBackupPathAsync()
     {
@@ -325,17 +390,10 @@ public partial class SettingsViewModel : ViewModelBase
         WinRT.Interop.InitializeWithWindow.Initialize(folderPicker, hWnd);
 
         StorageFolder folder = await folderPicker.PickSingleFolderAsync();
-        if (folder != null)
-        {
-            BackupPath = folder.Path;
-        }
+        if (folder != null) BackupPath = folder.Path;
     }
 
-    private void SetDefaultBackupPath()
-    {
-        string defaultPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Pango", "Backup");
-        BackupPath = defaultPath;
-    }
+    private void SetDefaultBackupPath() => BackupPath = GetDefaultPath();
 
     private async Task OpenBackupFolderAsync()
     {
@@ -343,85 +401,76 @@ public partial class SettingsViewModel : ViewModelBase
         {
             await Launcher.LaunchFolderPathAsync(BackupPath);
         }
+        else
+        {
+            SendNotification("BackupPathInvalid_Error", AppNotificationType.Warning);
+        }
     }
 
     private async Task SaveBackupSettingsAsync()
     {
-        if (string.IsNullOrWhiteSpace(BackupPath) || BackupPath.Length < 3 || Path.GetInvalidPathChars().Any(BackupPath.Contains))
+        if (string.IsNullOrWhiteSpace(BackupPath))
         {
             SendNotification("BackupPathInvalid_Error", AppNotificationType.Error);
             return;
         }
 
-        if (string.IsNullOrWhiteSpace(BackupPassword) || BackupPassword.Length < 3)
-        {
-            WeakReferenceMessenger.Default.Send(new InAppNotificationMessage(
-                "Password must be at least 3 characters long",
-                AppNotificationType.Error));
-            return;
-        }
-
         try
         {
-            if (!Directory.Exists(BackupPath))
-            {
-                Directory.CreateDirectory(BackupPath);
-            }
+            if (!Directory.Exists(BackupPath)) Directory.CreateDirectory(BackupPath);
 
             BackupSettings settings;
             if (File.Exists(_configPath))
             {
-                string existingJson = await File.ReadAllTextAsync(_configPath);
-                settings = JsonSerializer.Deserialize<BackupSettings>(existingJson) ?? new BackupSettings();
+                string json = await File.ReadAllTextAsync(_configPath);
+                settings = JsonSerializer.Deserialize<BackupSettings>(json) ?? new BackupSettings();
             }
             else
             {
                 settings = new BackupSettings();
             }
 
-            settings.Users ??= [];
-
             settings.TargetFolderPath = BackupPath;
             settings.IntervalMinutes = SelectedBackupInterval;
             settings.IsEnabled = IsBackupServiceEnabled;
+            settings.RetentionDays = RetentionDays;
+            settings.Users ??= [];
 
             string userName = _userContextProvider.GetUserName();
-            string absoluteSourcePath = _appDomainProvider.GetUserFolderPath(userName);
-
             var userProfile = new UserBackupProfile
             {
                 BackupPassword = this.BackupPassword,
-                SourceDataPath = absoluteSourcePath
+                SourceDataPath = _appDomainProvider.GetUserFolderPath(userName)
             };
 
-            if (!settings.Users.TryAdd(userName, userProfile))
-            {
-                settings.Users[userName] = userProfile;
-            }
+            if (!settings.Users.TryAdd(userName, userProfile)) settings.Users[userName] = userProfile;
 
-            string json = JsonSerializer.Serialize(settings);
-            await File.WriteAllTextAsync(_configPath, json);
-
+            await SaveSettingsToFileAsync(settings);
             SendNotification("BackupSaved_Message", AppNotificationType.Success);
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to save backup settings");
-            WeakReferenceMessenger.Default.Send(new InAppNotificationMessage(
-                $"Error: {ex.Message}",
-                AppNotificationType.Error));
+            WeakReferenceMessenger.Default.Send(new InAppNotificationMessage($"Error: {ex.Message}", AppNotificationType.Error));
         }
     }
 
     private void SendNotification(string resourceKey, AppNotificationType type)
     {
-        WeakReferenceMessenger.Default.Send(new InAppNotificationMessage(
-                ViewResourceLoader.GetString(resourceKey), type));
+        WeakReferenceMessenger.Default.Send(new InAppNotificationMessage(_resourceLoader.GetString(resourceKey), type));
     }
 
-    private static string GenerateRandomPassword()
+    private static string GenerateRandomPassword() => Guid.NewGuid().ToString("N")[..12].ToUpper();
+
+    private static ImportDestination LoadImportSetting()
     {
-        return Guid.NewGuid().ToString("N")[..12].ToUpper();
+        var val = ApplicationData.Current.LocalSettings.Values["ImportDestination"] as int?;
+        return (ImportDestination)(val ?? 0);
+    }
+
+    private static void SaveImportSetting(ImportDestination value)
+    {
+        ApplicationData.Current.LocalSettings.Values["ImportDestination"] = (int)value;
     }
 
     #endregion

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/SettingsViewModel.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/SettingsViewModel.cs
@@ -1,53 +1,90 @@
-﻿using CommunityToolkit.Mvvm.Messaging;
+﻿using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
+using Pango.Application.Common;
+using Pango.Application.Common.Interfaces.Services;
 using Pango.Desktop.Uwp.Core;
 using Pango.Desktop.Uwp.Core.Attributes;
 using Pango.Desktop.Uwp.Core.Enums;
 using Pango.Desktop.Uwp.Core.Utility;
 using Pango.Desktop.Uwp.Models;
 using Pango.Desktop.Uwp.Mvvm.Messages;
+using Pango.Desktop.Uwp.Mvvm.Models;
 using Pango.Desktop.Uwp.Views;
+using Pango.Persistence;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
 using Windows.Storage;
+using Windows.Storage.Pickers;
+using Windows.System;
 
 namespace Pango.Desktop.Uwp.ViewModels;
 
 [AppView(AppView.Settings)]
-public class SettingsViewModel : ViewModelBase
+public partial class SettingsViewModel : ViewModelBase
 {
     #region Fields
 
+    // Services
+    private readonly IUserContextProvider _userContextProvider;
+    private readonly IAppDomainProvider _appDomainProvider;
+
+    // Appearance & Behavior
     private AppLanguage _selectedLanguage;
     private AppTheme _selectedAppTheme;
     private bool _allowAutolock;
-    private KeyValuePair<int, string>?  _selectedLockOnIdleInMinutesItem;
+    private KeyValuePair<int, string>? _selectedLockOnIdleInMinutesItem;
+
+    // Backup Configuration
+    private string _configPath = string.Empty;
+    private string _backupPath = string.Empty;
+    private int _selectedBackupInterval;
+    private bool _isBackupServiceEnabled;
+    private string _backupPassword = string.Empty;
 
     #endregion
 
-    public SettingsViewModel(ILogger<SettingsViewModel> logger) : base(logger)
+    #region Constructor
+
+    public SettingsViewModel(
+        ILogger<SettingsViewModel> logger,
+        IUserContextProvider userContextProvider,
+        IAppDomainProvider appDomainProvider) : base(logger)
     {
+        _userContextProvider = userContextProvider;
+        _appDomainProvider = appDomainProvider;
+
+        // 1. Initialize Collections
         Languages = new ObservableCollection<AppLanguage>(AppLanguage.GetAppLanguageCollection());
-        AppThemes = new ObservableCollection<AppTheme>(Enum.GetValues(typeof(ElementTheme)).Cast<ElementTheme>().Select(e => new AppTheme { Name = ViewResourceLoader.GetString($"AppTheme_{e}"), Value = (int)e }));
-        
+        AppThemes = new ObservableCollection<AppTheme>(Enum.GetValues(typeof(ElementTheme))
+            .Cast<ElementTheme>()
+            .Select(e => new AppTheme { Name = ViewResourceLoader.GetString($"AppTheme_{e}"), Value = (int)e }));
+
         string localizedMinutes = ViewResourceLoader.GetString("Minute(-s)");
-        LockOnIdleInMinutesItems = new ObservableCollection<KeyValuePair<int, string>>(new List<KeyValuePair<int, string>>
-        {
+        LockOnIdleInMinutesItems = new ObservableCollection<KeyValuePair<int, string>>(
+        [
             new(1, $"1 {localizedMinutes}"),
             new(3, $"3 {localizedMinutes}"),
             new(5, $"5 {localizedMinutes}"),
             new(10, $"10 {localizedMinutes}"),
             new(15, $"15 {localizedMinutes}"),
             new(30, $"30 {localizedMinutes}")
-        });
+        ]);
 
+        BackupIntervals = new ObservableCollection<int>([1, 5, 10, 15, 20, 30, 45, 60]);
+
+        // 2. Initialize App Settings (Language/Theme)
         string appliedLocale = AppLanguageHelper.GetAppliedAppLanguage().Locale;
         _selectedLanguage = Languages.FirstOrDefault(e => e.Locale == appliedLocale) ?? Languages.First();
         _selectedAppTheme = AppThemes.First(e => e.Value == (int)AppThemeHelper.Theme);
 
+        // 3. Initialize Autolock Settings
         int? blockAppAfterIdleMinutes = (int?)ApplicationData.Current.LocalSettings.Values[Constants.Settings.BlockAppAfterIdleMinutes];
         if (blockAppAfterIdleMinutes.HasValue)
         {
@@ -59,9 +96,14 @@ public class SettingsViewModel : ViewModelBase
             _selectedLockOnIdleInMinutesItem = null;
             _allowAutolock = false;
         }
+
+        // 4. Initialize Backup Configuration
+        _ = InitializeBackupConfigAsync();
     }
 
-    #region Properties
+    #endregion
+
+    #region Properties - General
 
     public static string Version
     {
@@ -71,6 +113,10 @@ public class SettingsViewModel : ViewModelBase
             return version is null ? "undefined" : string.Format("{0}.{1}.{2}.{3}", version.Major, version.Minor, version.Build, version.Revision);
         }
     }
+
+    #endregion
+
+    #region Properties - Appearance & Language
 
     public ObservableCollection<AppLanguage> Languages { get; private set; }
 
@@ -94,7 +140,7 @@ public class SettingsViewModel : ViewModelBase
         get => _selectedAppTheme;
         set
         {
-            if(value != null)
+            if (value != null)
             {
                 ElementTheme? elementTheme = (ElementTheme)value.Value;
                 if (elementTheme.HasValue && elementTheme.Value != AppThemeHelper.Theme)
@@ -105,6 +151,10 @@ public class SettingsViewModel : ViewModelBase
             }
         }
     }
+
+    #endregion
+
+    #region Properties - Security (Autolock)
 
     public ObservableCollection<KeyValuePair<int, string>> LockOnIdleInMinutesItems { get; private set; }
 
@@ -127,6 +177,251 @@ public class SettingsViewModel : ViewModelBase
             SelectedLockOnIdleInMinutesItem = value ? LockOnIdleInMinutesItems[3] : null;
             SetProperty(ref _allowAutolock, value);
         }
+    }
+
+    #endregion
+
+    #region Properties - Backup
+
+    public ObservableCollection<int> BackupIntervals { get; }
+
+    public string BackupPath
+    {
+        get => _backupPath;
+        set => SetProperty(ref _backupPath, value);
+    }
+
+    public int SelectedBackupInterval
+    {
+        get => _selectedBackupInterval;
+        set => SetProperty(ref _selectedBackupInterval, value);
+    }
+
+    public bool IsBackupServiceEnabled
+    {
+        get => _isBackupServiceEnabled;
+        set => SetProperty(ref _isBackupServiceEnabled, value);
+    }
+
+    public string BackupPassword
+    {
+        get => _backupPassword;
+        set => SetProperty(ref _backupPassword, value);
+    }
+
+    #endregion
+
+    #region Commands - Backup
+
+    private RelayCommand? _browseBackupPathCommand;
+    public RelayCommand BrowseBackupPathCommand => _browseBackupPathCommand ??= new RelayCommand(async () => await BrowseBackupPathAsync());
+
+    private RelayCommand? _setDefaultBackupPathCommand;
+    public RelayCommand SetDefaultBackupPathCommand => _setDefaultBackupPathCommand ??= new RelayCommand(SetDefaultBackupPath);
+
+    private RelayCommand? _openBackupFolderCommand;
+    public RelayCommand OpenBackupFolderCommand => _openBackupFolderCommand ??= new RelayCommand(async () => await OpenBackupFolderAsync());
+
+    private RelayCommand? _saveBackupSettingsCommand;
+    public RelayCommand SaveBackupSettingsCommand => _saveBackupSettingsCommand ??= new RelayCommand(async () => await SaveBackupSettingsAsync());
+
+    private RelayCommand? _cancelBackupChangesCommand;
+    public RelayCommand CancelBackupChangesCommand => _cancelBackupChangesCommand ??= new RelayCommand(async () => await LoadBackupSettingsAsync());
+
+    #endregion
+
+    #region Methods - Backup Implementation
+
+    private async Task InitializeBackupConfigAsync()
+    {
+        // Path to ProgramData/Pango/backup_config.json
+        string commonAppData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+        string configDir = Path.Combine(commonAppData, "Pango");
+
+        if (!Directory.Exists(configDir))
+        {
+            Directory.CreateDirectory(configDir);
+        }
+
+        _configPath = Path.Combine(configDir, "backup_config.json");
+
+        await LoadBackupSettingsAsync();
+    }
+
+    private async Task LoadBackupSettingsAsync()
+    {
+        try
+        {
+            BackupSettings? settings = null;
+
+            if (File.Exists(_configPath))
+            {
+                string json = await File.ReadAllTextAsync(_configPath);
+                settings = JsonSerializer.Deserialize<BackupSettings>(json);
+            }
+
+            settings ??= new BackupSettings();
+            settings.Users ??= [];
+
+            BackupPath = string.IsNullOrEmpty(settings.TargetFolderPath) ? GetDefaultPath() : settings.TargetFolderPath;
+            SelectedBackupInterval = settings.IntervalMinutes > 0 ? settings.IntervalMinutes : 60;
+            IsBackupServiceEnabled = settings.IsEnabled;
+
+            string currentUser = _userContextProvider.GetUserName();
+            bool needToSaveImmediately = false;
+
+            if (settings.Users.TryGetValue(currentUser, out UserBackupProfile? profile))
+            {
+                BackupPassword = profile.BackupPassword;
+            }
+            else
+            {
+                BackupPassword = GenerateRandomPassword();
+
+                string sourcePath = _appDomainProvider.GetUserFolderPath(currentUser);
+
+                settings.Users.Add(currentUser, new UserBackupProfile
+                {
+                    BackupPassword = BackupPassword,
+                    SourceDataPath = sourcePath
+                });
+
+                needToSaveImmediately = true;
+            }
+
+            if (needToSaveImmediately)
+            {
+                await SaveSettingsToFileAsync(settings);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading backup settings");
+            SetDefaultBackupPath();
+            BackupPassword = GenerateRandomPassword();
+        }
+    }
+
+    private async Task SaveSettingsToFileAsync(BackupSettings settings)
+    {
+        string json = JsonSerializer.Serialize(settings);
+        await File.WriteAllTextAsync(_configPath, json);
+    }
+
+    private static string GetDefaultPath()
+    {
+        return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Pango", "Backup");
+    }
+
+    private async Task BrowseBackupPathAsync()
+    {
+        FolderPicker folderPicker = new();
+        folderPicker.FileTypeFilter.Add("*");
+
+        var window = App.Current.CurrentWindow;
+        if (window == null) return;
+
+        var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(window);
+        WinRT.Interop.InitializeWithWindow.Initialize(folderPicker, hWnd);
+
+        StorageFolder folder = await folderPicker.PickSingleFolderAsync();
+        if (folder != null)
+        {
+            BackupPath = folder.Path;
+        }
+    }
+
+    private void SetDefaultBackupPath()
+    {
+        string defaultPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Pango", "Backup");
+        BackupPath = defaultPath;
+    }
+
+    private async Task OpenBackupFolderAsync()
+    {
+        if (Directory.Exists(BackupPath))
+        {
+            await Launcher.LaunchFolderPathAsync(BackupPath);
+        }
+    }
+
+    private async Task SaveBackupSettingsAsync()
+    {
+        if (string.IsNullOrWhiteSpace(BackupPath) || BackupPath.Length < 3 || Path.GetInvalidPathChars().Any(BackupPath.Contains))
+        {
+            SendNotification("BackupPathInvalid_Error", AppNotificationType.Error);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(BackupPassword) || BackupPassword.Length < 3)
+        {
+            WeakReferenceMessenger.Default.Send(new InAppNotificationMessage(
+                "Password must be at least 3 characters long",
+                AppNotificationType.Error));
+            return;
+        }
+
+        try
+        {
+            if (!Directory.Exists(BackupPath))
+            {
+                Directory.CreateDirectory(BackupPath);
+            }
+
+            BackupSettings settings;
+            if (File.Exists(_configPath))
+            {
+                string existingJson = await File.ReadAllTextAsync(_configPath);
+                settings = JsonSerializer.Deserialize<BackupSettings>(existingJson) ?? new BackupSettings();
+            }
+            else
+            {
+                settings = new BackupSettings();
+            }
+
+            settings.Users ??= [];
+
+            settings.TargetFolderPath = BackupPath;
+            settings.IntervalMinutes = SelectedBackupInterval;
+            settings.IsEnabled = IsBackupServiceEnabled;
+
+            string userName = _userContextProvider.GetUserName();
+            string absoluteSourcePath = _appDomainProvider.GetUserFolderPath(userName);
+
+            var userProfile = new UserBackupProfile
+            {
+                BackupPassword = this.BackupPassword,
+                SourceDataPath = absoluteSourcePath
+            };
+
+            if (!settings.Users.TryAdd(userName, userProfile))
+            {
+                settings.Users[userName] = userProfile;
+            }
+
+            string json = JsonSerializer.Serialize(settings);
+            await File.WriteAllTextAsync(_configPath, json);
+
+            SendNotification("BackupSaved_Message", AppNotificationType.Success);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to save backup settings");
+            WeakReferenceMessenger.Default.Send(new InAppNotificationMessage(
+                $"Error: {ex.Message}",
+                AppNotificationType.Error));
+        }
+    }
+
+    private void SendNotification(string resourceKey, AppNotificationType type)
+    {
+        WeakReferenceMessenger.Default.Send(new InAppNotificationMessage(
+                ViewResourceLoader.GetString(resourceKey), type));
+    }
+
+    private static string GenerateRandomPassword()
+    {
+        return Guid.NewGuid().ToString("N")[..12].ToUpper();
     }
 
     #endregion

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/ExportImportView.xaml
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/ExportImportView.xaml
@@ -197,64 +197,34 @@
             </Setter>
         </Style>
 
-        <DataTemplate x:Name="FolderTemplate"
-                      x:DataType="local:PangoExplorerItem">
-            <TreeViewItem AutomationProperties.Name="{Binding Name}"
-                          ItemsSource="{Binding Children}" 
-                          IsExpanded="False" 
+        <DataTemplate x:Name="FolderTemplate" x:DataType="local:PangoExplorerItem">
+            <TreeViewItem IsExpanded="{Binding IsExpanded, Mode=TwoWay}" 
+                          ItemsSource="{Binding Children}"
                           Visibility="{Binding IsVisible, Converter={StaticResource BoolToVisibilityConvereter}}">
-                <!--<TreeViewItem.ContextFlyout>
-                    <MenuFlyout>
-                        <MenuFlyoutItem x:Name="Edit_CatalogContextMenuItem" Text="{loc:StringResource Key=Edit}" Icon="Edit" Click="EditContextMenuItem_Click"/>
-                        <MenuFlyoutItem x:Name="Delete_CatalogContextMenuItem" Text="{loc:StringResource Key=Delete}" Icon="Delete" Click="DeleteContextMenuItem_Click"/>
-                        <MenuFlyoutSeparator/>
-                        <MenuFlyoutItem x:Name="AddPassword_CatalogContextMenuItem" Text="{loc:StringResource Key=AddPassword}" Icon="Add" Click="AddPassword_CatalogContextMenuItem_Click"/>
-                        <MenuFlyoutItem x:Name="AddCatalog_CatalogContextMenuItem" Text="{loc:StringResource Key=AddNewCatalog}" Icon="NewFolder" Click="AddCatalog_CatalogContextMenuItem_Click"/>
-                    </MenuFlyout>
-                </TreeViewItem.ContextFlyout>-->
-                <StackPanel Orientation="Horizontal">
-                    <Image Width="20"
-                       Source="../Assets/folder.png"/>
-                    <TextBlock Margin="0,0,10,0"/>
-                    <TextBlock Text="{Binding Name}" />
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <CheckBox IsChecked="{Binding IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                              MinWidth="0" Margin="0,0,8,0"/>
+                    <Image Width="20" Source="../Assets/folder.png"/>
+                    <TextBlock Text="{Binding Name}" VerticalAlignment="Center"/>
                 </StackPanel>
             </TreeViewItem>
         </DataTemplate>
 
-        <DataTemplate x:Name="FileTemplate"
-                      x:DataType="local:PangoExplorerItem">
-            <TreeViewItem HorizontalAlignment="Stretch"
-                          Padding="0 0 10 0"
-                          HorizontalContentAlignment="Stretch"
-                          AutomationProperties.Name="{Binding Name}"
-                          Visibility="{Binding IsVisible, Converter={StaticResource BoolToVisibilityConvereter}}">
-
-                <!--<TreeViewItem.ContextFlyout>
-                    <MenuFlyout >
-                        <MenuFlyoutItem x:Name="SeePassword_PasswordContextMenuItem" Text="{loc:StringResource Key=SeePassword}" Click="SeeContextMenuItem_Click">
-                            <MenuFlyoutItem.Icon>
-                                <FontIcon Glyph="&#xE7B3;"/>
-                            </MenuFlyoutItem.Icon>
-                        </MenuFlyoutItem>
-                        <MenuFlyoutItem x:Name="EditPassword_PasswordContextMenuItem" Text="{loc:StringResource Key=Edit}" Icon="Edit" Click="EditContextMenuItem_Click"/>
-                        <MenuFlyoutItem x:Name="DeletePassword_PasswordContextMenuItem" Text="{loc:StringResource Key=Delete}" Icon="Delete" Click="DeleteContextMenuItem_Click"/>
-                        <MenuFlyoutSeparator/>
-                        <MenuFlyoutItem x:Name="CopyPassword_PasswordContextMenuItem" Text="{loc:StringResource Key=CopyPassword}" Icon="Copy" Click="CopyPassword_PasswordContextMenuItem_Click"/>
-                    </MenuFlyout>
-                </TreeViewItem.ContextFlyout>-->
-                <Grid HorizontalAlignment="Stretch">
+        <DataTemplate x:Name="FileTemplate" x:DataType="local:PangoExplorerItem">
+            <TreeViewItem Visibility="{Binding IsVisible, Converter={StaticResource BoolToVisibilityConvereter}}">
+                <Grid>
                     <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
 
-                    <FontIcon Glyph="&#xE8D7;"
-                          Margin="5,2"
-                          FontSize="{StaticResource FontIconSize}"/>
+                    <CheckBox Grid.Column="0" 
+                              IsChecked="{Binding IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                              MinWidth="0" Margin="0,0,8,0"/>
 
-                    <TextBlock Grid.Column="1" 
-                           Text="{Binding Name}"
-                           VerticalAlignment="Center"/>
+                    <FontIcon Grid.Column="1" Glyph="&#xE8D7;" FontSize="{StaticResource FontIconSize}" Margin="0,0,8,0"/>
+                    <TextBlock Grid.Column="2" Text="{Binding Name}" VerticalAlignment="Center"/>
                 </Grid>
             </TreeViewItem>
         </DataTemplate>
@@ -265,74 +235,45 @@
     </Page.Resources>
 
     <Grid>
-        <Grid x:Name="RootGrid"
-              Margin="{StaticResource PageContentContainerMargin}">
-
+        <Grid x:Name="RootGrid" Margin="{StaticResource PageContentContainerMargin}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <Grid Grid.Row="0">
-                <TextBlock Margin="0" 
-                           Text="{Binding TitleText}"
-                           Style="{StaticResource HeaderTextBlockStyle}"/>
-            </Grid>
+            <TextBlock Margin="0" Text="{Binding TitleText}" Style="{StaticResource HeaderTextBlockStyle}"/>
 
-            <Pivot Grid.Row="1"
-                   x:Name="ExportImport_Pivot"
-                   Margin="0"
-                   IsLocked="True"
-                   SelectedIndex="{Binding SelectedOption, Mode=TwoWay}">
+            <Pivot Grid.Row="1" x:Name="ExportImport_Pivot" Margin="0" IsLocked="True" SelectedIndex="{Binding SelectedOption, Mode=TwoWay}">
+                <!-- Header Template (Empty) -->
                 <Pivot.HeaderTemplate>
                     <DataTemplate>
-                        <StackPanel Width="0"
-                                Height="0">
-                            <TextBlock Text="{Binding}" />
-                        </StackPanel>
+                        <StackPanel Width="0" Height="0"/>
                     </DataTemplate>
                 </Pivot.HeaderTemplate>
 
+                <!-- 0: Main Menu -->
                 <PivotItem Margin="0">
-                    <Grid HorizontalAlignment="Center"
-                          VerticalAlignment="Center">
-                        <StackPanel Orientation="Vertical"
-                                    VerticalAlignment="Center"
-                                    HorizontalAlignment="Center"
-                                    MaxWidth="400">
-                            <TextBlock Text="{loc:StringResource Key=ExportAndImportDescriptionLabel}"
-                                       TextWrapping="WrapWholeWords"
-                                       HorizontalAlignment="Center"/>
-                            <StackPanel Orientation="Horizontal"
-                                        HorizontalAlignment="Center">
-                                <Button Margin="10" 
-                                        Content="{loc:StringResource Key=ExportDataButtonContent}"
-                                        HorizontalAlignment="Center"
-                                        Style="{StaticResource AccentButtonStyle}"
-                                        Command="{Binding Path=NavigateToOptionCommand}">
+                    <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <StackPanel Orientation="Vertical" MaxWidth="400" Spacing="20">
+                            <TextBlock Text="{loc:StringResource Key=ExportAndImportDescriptionLabel}" TextWrapping="WrapWholeWords" HorizontalAlignment="Center" TextAlignment="Center"/>
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="10">
+                                <Button Content="{loc:StringResource Key=ExportDataButtonContent}" Style="{StaticResource AccentButtonStyle}" Command="{Binding NavigateToOptionCommand}">
                                     <Button.CommandParameter>
                                         <x:Int32>1</x:Int32>
                                     </Button.CommandParameter>
                                 </Button>
-
-                                <TextBlock Margin="5"
-                                           VerticalAlignment="Center"
-                                           Text="{loc:StringResource Key=Or}"/>
-
-                                <Button Margin="10" 
-                                        Content="{loc:StringResource Key=ImportDataButtonContent}"
-                                        HorizontalAlignment="Center"
-                                        Style="{StaticResource AccentButtonStyle}"
-                                        Command="{Binding Path=NavigateToOptionCommand}">
+                                <TextBlock Text="{loc:StringResource Key=Or}" VerticalAlignment="Center"/>
+                                <Button Content="{loc:StringResource Key=ImportDataButtonContent}" Style="{StaticResource AccentButtonStyle}" Command="{Binding NavigateToOptionCommand}">
                                     <Button.CommandParameter>
                                         <x:Int32>2</x:Int32>
-                                    </Button.CommandParameter>                                
+                                    </Button.CommandParameter>
                                 </Button>
                             </StackPanel>
                         </StackPanel>
                     </Grid>
                 </PivotItem>
 
+                <!-- 1: Export Selection -->
                 <PivotItem Margin="0">
                     <Grid>
                         <Grid.RowDefinitions>
@@ -340,32 +281,18 @@
                             <RowDefinition Height="*"/>
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
+                        <TextBlock Text="{loc:StringResource Key='SelectItemsToExport'}" Style="{StaticResource SubtitleTextBlockStyle}"/>
 
-                        <TextBlock Margin="0" 
-                                   Text="{loc:StringResource Key='SelectItemsToExport'}"
-                                   Style="{StaticResource SubtitleTextBlockStyle}"/>
-
-                        <Grid Grid.Row="1">
+                        <Grid Grid.Row="1" Margin="0,10">
                             <TreeView x:Name="PasswordsTreeView" 
-                                      Margin="10 "
-                                      SelectionMode="Multiple"
-                                      ItemsSource="{Binding Path=Passwords}"                                      
-                                      ItemContainerStyle="{StaticResource MUX_MultiSelectTreeViewItemStyle}"
-                                      ItemTemplateSelector="{StaticResource PasswordExplorerItemTemplateSelector}">
-                            </TreeView>
+                                      SelectionMode="None" 
+                                      ItemsSource="{Binding Passwords}" 
+                                      ItemTemplateSelector="{StaticResource PasswordExplorerItemTemplateSelector}"/>
                         </Grid>
-                        
-                        <StackPanel Grid.Row="2" 
-                                    Margin="10" 
-                                    Orientation="Horizontal"
-                                    HorizontalAlignment="Right">
-                            <Button Margin="5" 
-                                    Content="{loc:StringResource Key='ExportDataButtonContent'}"
-                                    Style="{StaticResource AccentButtonStyle}"
-                                    Command="{Binding Path=ExportDataCommand}"/>
-                            <Button Margin="5" 
-                                    Content="{loc:StringResource Key='Cancel'}"
-                                    Command="{Binding Path=NavigateToOptionCommand}">
+
+                        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10">
+                            <Button Content="{loc:StringResource Key='ExportDataButtonContent'}" Style="{StaticResource AccentButtonStyle}" Command="{Binding ExportDataCommand}"/>
+                            <Button Content="{loc:StringResource Key='Cancel'}" Command="{Binding NavigateToOptionCommand}">
                                 <Button.CommandParameter>
                                     <x:Int32>0</x:Int32>
                                 </Button.CommandParameter>
@@ -374,6 +301,7 @@
                     </Grid>
                 </PivotItem>
 
+                <!-- 2: Import File Selection -->
                 <PivotItem>
                     <Grid>
                         <Grid.RowDefinitions>
@@ -382,59 +310,52 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
-
-                        <TextBlock Margin="0" 
-                                   Text="{loc:StringResource Key='SelectFile_Title'}"
-                                   Style="{StaticResource SubtitleTextBlockStyle}"/>
-
-                        <TextBlock Grid.Row="1" 
-                                   Margin="0" 
-                                   Text="{loc:StringResource Key='SelectFile_Hint'}"
-                                   Style="{StaticResource BodyTextBlockStyle}"/>
-
-                        <StackPanel Grid.Row="2" 
-                                    Margin="10, 20, 0, 0"
-                                    VerticalAlignment="Top" 
-                                    Orientation="Horizontal">
-                            <Button x:Name="PickPngxFileButton" 
-                                    Content="{loc:StringResource Key='Select_Button'}"
-                                    Click="PickPngxFileButton_Click" 
-                                    VerticalAlignment="Center"
-                                    Margin="5"/>
-
-                            <FontIcon Glyph="&#xE8E5;"
-                                      Margin="10,2,0,2"
-                                      VerticalAlignment="Center"
-                                      FontSize="{StaticResource FontIconSize}"
-                                      Visibility="{Binding Text, ElementName=PickPngxFileOutputTextBlock, Converter={StaticResource NullOrEmptyToCollapsedConverter}}"/>
-
-                            <TextBlock x:Name="PickPngxFileOutputTextBlock" 
-                                       TextWrapping="Wrap" 
-                                       Text="{Binding ImportFilePath}"
-                                       VerticalAlignment="Center"
-                                       Padding="0"
-                                       Margin="5"/>
-                        </StackPanel>
-
-                        <Grid Grid.Row="3"
-                              Margin="0, 10">
-                            <StackPanel Orientation="Horizontal"
-                                        HorizontalAlignment="Right">
-                                <Button Margin="5" 
-                                        Content="{loc:StringResource Key='ImportDataButtonContent'}"
-                                        Style="{StaticResource AccentButtonStyle}"
-                                        Command="{Binding ImportDataCommand}"/>
-
-                                <Button Margin="5"
-                                        Content="{loc:StringResource Key='Cancel'}"
-                                        Command="{Binding NavigateToOptionCommand}">
-                                    <Button.CommandParameter>
-                                        <x:Int32>0</x:Int32>
-                                    </Button.CommandParameter>
-                                </Button>
+                        <TextBlock Text="{loc:StringResource Key='SelectFile_Title'}" Style="{StaticResource SubtitleTextBlockStyle}"/>
+                        <TextBlock Grid.Row="1" Text="{loc:StringResource Key='SelectFile_Hint'}" Style="{StaticResource BodyTextBlockStyle}" Margin="0,5,0,0"/>
+                        <StackPanel Grid.Row="2" Margin="0,20,0,0" Orientation="Horizontal" Spacing="10">
+                            <Button Content="{loc:StringResource Key='Select_Button'}" Click="PickPngxFileButton_Click"/>
+                            <StackPanel Orientation="Horizontal" Visibility="{Binding Text, ElementName=PickPngxFileOutputTextBlock, Converter={StaticResource NullOrEmptyToCollapsedConverter}}">
+                                <FontIcon Glyph="&#xE8E5;" FontSize="{StaticResource FontIconSize}" VerticalAlignment="Center"/>
+                                <TextBlock x:Name="PickPngxFileOutputTextBlock" Text="{Binding ImportFilePath}" VerticalAlignment="Center" Margin="5,0,0,0"/>
                             </StackPanel>
+                        </StackPanel>
+                        <StackPanel Grid.Row="3" Margin="0,20" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10">
+                            <Button Content="{loc:StringResource Key='ImportDataButtonContent'}" Style="{StaticResource AccentButtonStyle}" Command="{Binding ReadImportFileCommand}"/>
+                            <Button Content="{loc:StringResource Key='Cancel'}" Command="{Binding NavigateToOptionCommand}">
+                                <Button.CommandParameter>
+                                    <x:Int32>0</x:Int32>
+                                </Button.CommandParameter>
+                            </Button>
+                        </StackPanel>
+                    </Grid>
+                </PivotItem>
+
+                <!-- 3: Import Item Selection -->
+                <PivotItem Margin="0">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+                        <TextBlock Text="{loc:StringResource Key='SelectItemsToImport'}" Style="{StaticResource SubtitleTextBlockStyle}"/>
+
+                        <Grid Grid.Row="1" Margin="0,10">
+                            <TreeView x:Name="ImportTreeView" 
+                                      SelectionMode="None"
+                                      ItemsSource="{Binding ImportItems}"                                      
+                                      ItemTemplateSelector="{StaticResource PasswordExplorerItemTemplateSelector}">
+                            </TreeView>
                         </Grid>
 
+                        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10">
+                            <Button Content="{loc:StringResource Key='ImportDataButtonContent'}" Style="{StaticResource AccentButtonStyle}" Command="{Binding FinalizeImportCommand}"/>
+                            <Button Content="{loc:StringResource Key='Cancel'}" Command="{Binding NavigateToOptionCommand}">
+                                <Button.CommandParameter>
+                                    <x:Int32>0</x:Int32>
+                                </Button.CommandParameter>
+                            </Button>
+                        </StackPanel>
                     </Grid>
                 </PivotItem>
             </Pivot>

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/ExportImportView.xaml.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/ExportImportView.xaml.cs
@@ -1,11 +1,14 @@
+using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Navigation;
 using Pango.Desktop.Uwp.Core.Attributes;
+using Pango.Desktop.Uwp.Dialogs.ViewModels;
 using Pango.Desktop.Uwp.Models;
 using Pango.Desktop.Uwp.ViewModels;
 using Pango.Desktop.Uwp.Views.Abstract;
 using System;
-using System.Linq;
 using Windows.Storage.Pickers;
 
 // To learn more about WinUI, the WinUI project structure,
@@ -25,79 +28,86 @@ public sealed partial class ExportImportView : PageBase
         this.InitializeComponent();
         DataContext = App.Host.Services.GetRequiredService<ExportImportViewModel>();
 
-        this.PasswordsTreeView.SelectionChanged += PasswordsTreeView_SelectionChanged;
+        // Subscribe to ItemInvoked events for checkbox toggle logic
+        this.PasswordsTreeView.ItemInvoked += OnTreeViewItemInvoked;
+        this.ImportTreeView.ItemInvoked += OnTreeViewItemInvoked;
     }
 
-    private void PasswordsTreeView_SelectionChanged(Microsoft.UI.Xaml.Controls.TreeView sender, Microsoft.UI.Xaml.Controls.TreeViewSelectionChangedEventArgs args)
+    protected override void OnNavigatedTo(NavigationEventArgs e)
     {
-        if (args.AddedItems.Any())
+        base.OnNavigatedTo(e);
+
+        // Safe registration
+        WeakReferenceMessenger.Default.Register<ImportPreviewReadyMessage>(this, (r, m) =>
         {
-            foreach (var item in args.AddedItems)
+            // Check if page is still valid
+            if (this.XamlRoot == null) return;
+
+            // Dispatch to UI thread to avoid threading issues
+            this.DispatcherQueue.TryEnqueue(() =>
             {
-                if (item is PangoExplorerItem explorerItem)
+                if (ViewModel is ExportImportViewModel vm)
                 {
-                    if (!explorerItem.IsSelected)
-                    {
-                        explorerItem.IsSelected = true;
-
-                        if(explorerItem.Parent != null)
-                        {
-                            explorerItem.Parent.IsSelected = true;
-                        }
-                    }
+                    _ = vm.HandleImportPreviewAsync(m.Value);
                 }
-            }
-        }
-
-        if (args.RemovedItems.Any())
-        {
-            foreach (var item in args.RemovedItems)
-            {
-                if (item is PangoExplorerItem explorerItem)
-                {
-                    explorerItem.IsSelected = false;
-                }
-            }
-        }
-
-        ((ExportImportViewModel)ViewModel).ExportDataCommand.NotifyCanExecuteChanged();
+            });
+        });
     }
 
+    protected override void OnNavigatedFrom(NavigationEventArgs e)
+    {
+        base.OnNavigatedFrom(e);
+        WeakReferenceMessenger.Default.UnregisterAll(this);
+    }
+
+    // Handle TreeView item clicks to toggle checkbox selection
+    private void OnTreeViewItemInvoked(TreeView sender, TreeViewItemInvokedEventArgs args)
+    {
+        if (args.InvokedItem is PangoExplorerItem item)
+        {
+            // Toggle selection state
+            item.IsSelected = !item.IsSelected;
+
+            // Notify commands about selection change
+            if (ViewModel is ExportImportViewModel vm)
+            {
+                if (sender == PasswordsTreeView)
+                    vm.ExportDataCommand.NotifyCanExecuteChanged();
+                else if (sender == ImportTreeView)
+                    vm.FinalizeImportCommand.NotifyCanExecuteChanged();
+            }
+        }
+    }
+
+    // Handles picking the .pngx file
     private async void PickPngxFileButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
     {
-        if (ViewModel is not ExportImportViewModel viewModel)
+        if (ViewModel is not ExportImportViewModel viewModel) return;
+
+        try
         {
-            return;
+            var openPicker = new FileOpenPicker();
+
+            // Get window handle safely
+            var window = App.Current.CurrentWindow;
+            if (window == null) return;
+
+            var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(window);
+            WinRT.Interop.InitializeWithWindow.Initialize(openPicker, hWnd);
+
+            openPicker.ViewMode = PickerViewMode.Thumbnail;
+            openPicker.SuggestedStartLocation = PickerLocationId.Downloads;
+            openPicker.FileTypeFilter.Add(".pngx");
+
+            var file = await openPicker.PickSingleFileAsync();
+            if (file != null)
+            {
+                viewModel.ImportFilePath = file.Path;
+            }
         }
-
-        viewModel.ImportFilePath = string.Empty;
-
-        // Create a file picker
-        var openPicker = new Windows.Storage.Pickers.FileOpenPicker();
-
-        // See the sample code below for how to make the window accessible from the App class.
-        var window = App.Current.CurrentWindow;
-
-        // Retrieve the window handle (HWND) of the current WinUI 3 window.
-        var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(window);
-
-        // Initialize the file picker with the window handle (HWND).
-        WinRT.Interop.InitializeWithWindow.Initialize(openPicker, hWnd);
-
-        // Set options for your file picker
-        openPicker.ViewMode = PickerViewMode.Thumbnail;
-        openPicker.SuggestedStartLocation = PickerLocationId.Downloads;
-        openPicker.FileTypeFilter.Add(".pngx");
-
-        // Open the picker for the user to pick a file
-        var file = await openPicker.PickSingleFileAsync();
-        if (file != null)
+        catch (Exception ex)
         {
-            viewModel.ImportFilePath = file.Path;
-        }
-        else
-        {
-            viewModel.ImportFilePath = string.Empty;
+            Logger.LogError(ex, "Error picking file");
         }
     }
 }

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/MainAppView.xaml
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/MainAppView.xaml
@@ -19,6 +19,7 @@
                              IsBackButtonVisible="Collapsed"
                              IsBackEnabled="False"
                              OpenPaneLength="200"
+                             CompactPaneLength="48"
                              IsSettingsVisible="True"
                              IsTitleBarAutoPaddingEnabled="False"
                              ItemInvoked="NavigationView_ItemInvoked">

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/SettingsView.xaml
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/SettingsView.xaml
@@ -6,6 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:toolkit="using:CommunityToolkit.WinUI.Controls"
     xmlns:loc="using:Pango.Desktop.Uwp.Core.Localization"
+    xmlns:controls="using:Pango.Desktop.Uwp.Controls"
     xmlns:viewmodels="using:Pango.Desktop.Uwp.ViewModels"
     xmlns:abstract="using:Pango.Desktop.Uwp.Views.Abstract"
     d:DataContext="{d:DesignInstance Type=viewmodels:SettingsViewModel}"
@@ -18,147 +19,178 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        
+
         <TextBlock Text="{loc:StringResource Key='Settings'}"
                    Style="{StaticResource HeaderTextBlockStyle}"/>
 
-        <!-- Content -->
-        <ScrollViewer Grid.Row="1">
-            <StackPanel Margin="{StaticResource PageContentContainerMargin}" Spacing="20">
-
-                <!-- Language Section -->
-                <StackPanel Margin="{StaticResource ControlSectionMargin}">
-                    <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text="{loc:StringResource Key=Language}" />
-                    <TextBlock
-                        Margin="0,10,0,5"
-                        Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
-                        Text="{loc:StringResource Key=ChooseApplicationLanguage}" />
-                    <ComboBox
-                        MinWidth="200"
-                        DisplayMemberPath="Name"
-                        ItemsSource="{Binding Languages}"
-                        SelectedItem="{Binding SelectedLanguage, Mode=TwoWay}" />
-                </StackPanel>
-
-                <!-- Appearance Section -->
-                <StackPanel Margin="{StaticResource ControlSectionMargin}">
-                    <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text="{loc:StringResource Key=Appearance}" />
-                    <TextBlock
-                        Margin="0,10,0,5"
-                        Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
-                        Text="{loc:StringResource Key=Theme}" />
-                    <ComboBox
-                        MinWidth="200"
-                        DisplayMemberPath="Name"
-                        ItemsSource="{Binding AppThemes}"
-                        SelectedItem="{Binding SelectedAppTheme, Mode=TwoWay}" />
-                </StackPanel>
+        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+            <StackPanel Orientation="Vertical" Spacing="8" Padding="0,0,20,40">
 
                 <!-- Security Section -->
-                <StackPanel Margin="{StaticResource ControlSectionMargin}">
-                    <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text="{loc:StringResource Key=Security}" />
-                    <ToggleSwitch
-                        Margin="0,10,0,0"
-                        Header="{loc:StringResource Key=Autolock}"
-                        IsOn="{Binding AllowAutolock, Mode=TwoWay}" />
-                    <TextBlock
-                        Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
-                        Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{loc:StringResource Key=AutolockDescription}" />
-
-                    <StackPanel Visibility="{Binding AllowAutolock, Converter={StaticResource BoolToVisibilityConvereter}}">
-                        <TextBlock Margin="0,10,0,5" Text="{loc:StringResource Key=AutolockAfterMinutes}" />
-                        <ComboBox
-                            MinWidth="200"
-                            DisplayMemberPath="Value"
-                            ItemsSource="{Binding LockOnIdleInMinutesItems}"
-                            SelectedItem="{Binding SelectedLockOnIdleInMinutesItem, Mode=TwoWay}" />
-                    </StackPanel>
+                <TextBlock Text="{loc:StringResource Key='Security'}"
+                           Style="{StaticResource SectionSubtitleTextBlockStyle}"/>
+                <StackPanel Orientation="Vertical" Spacing="4" Margin="{StaticResource ControlSectionMargin}">
+                    <toolkit:SettingsCard Header="{loc:StringResource Key='Autolock'}"
+                                          Description="{loc:StringResource Key='AutolockDescription'}">
+                        <ToggleSwitch IsOn="{Binding AllowAutolock, Mode=TwoWay}"
+                                      OnContent="{loc:StringResource Key='ToggleSwitch_On'}"
+                                      OffContent="{loc:StringResource Key='ToggleSwitch_Off'}"/>
+                    </toolkit:SettingsCard>
+                    <toolkit:SettingsCard Header="{loc:StringResource Key='AutolockAfterMinutes'}"
+                                          Visibility="{Binding AllowAutolock, Converter={StaticResource BoolToVisibilityConvereter}}">
+                        <ComboBox DisplayMemberPath="Value"
+                                  SelectedValuePath="Key"
+                                  ItemsSource="{Binding LockOnIdleInMinutesItems}"
+                                  SelectedItem="{Binding SelectedLockOnIdleInMinutesItem, Mode=TwoWay}"
+                                  MinWidth="150"/>
+                    </toolkit:SettingsCard>
                 </StackPanel>
 
-                <!-- BACKUP SECTION -->
-                <StackPanel Margin="{StaticResource ControlSectionMargin}">
-                    <TextBlock Text="{loc:StringResource Key='BackupSettings_Header'}" Style="{StaticResource SubtitleTextBlockStyle}" />
+                <!-- Backup Section -->
+                <TextBlock Text="{loc:StringResource Key='BackupSettings_Header'}"
+                           Style="{StaticResource SectionSubtitleTextBlockStyle}"/>
 
-                    <!-- Service Toggle -->
-                    <ToggleSwitch 
-                        Margin="0,10,0,0"
-                        IsOn="{Binding IsBackupServiceEnabled, Mode=TwoWay}" 
-                        Header="{loc:StringResource Key='BackupService_Toggle'}"/>
+                <toolkit:SettingsExpander IsExpanded="True" 
+                                          Margin="{StaticResource ControlSectionMargin}">
 
-                    <!-- Path Selection -->
-                    <TextBlock Margin="0,15,0,5" Text="{loc:StringResource Key='BackupPath_Label'}" />
-                    <Grid ColumnSpacing="10">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <TextBox Text="{Binding BackupPath, Mode=TwoWay}" IsReadOnly="True" />
-                        <Button Grid.Column="1" Content="{loc:StringResource Key='Browse_Button'}" Command="{Binding BrowseBackupPathCommand}" />
-                    </Grid>
+                    <toolkit:SettingsExpander.Header>
+                        <Grid>
+                            <StackPanel>
+                                <TextBlock Text="{loc:StringResource Key='BackupService_Toggle'}" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                <TextBlock Text="{loc:StringResource Key='BackupServiceDescription'}" Style="{StaticResource CaptionTextBlockStyle}" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                            </StackPanel>
+                        </Grid>
+                    </toolkit:SettingsExpander.Header>
 
-                    <!-- Path Buttons -->
-                    <StackPanel Orientation="Horizontal" Spacing="10" Margin="0,10,0,0">
-                        <Button Content="{loc:StringResource Key='DefaultPath_Button'}" Command="{Binding SetDefaultBackupPathCommand}" />
-                        <Button Content="{loc:StringResource Key='OpenFolder_Button'}" Command="{Binding OpenBackupFolderCommand}" />
-                    </StackPanel>
+                    <ToggleSwitch IsOn="{Binding IsBackupServiceEnabled, Mode=TwoWay}" 
+                                  OnContent="{loc:StringResource Key='ToggleSwitch_On'}"
+                                  OffContent="{loc:StringResource Key='ToggleSwitch_Off'}"/>
 
-                    <!-- Frequency -->
-                    <TextBlock Margin="0,15,0,5" Text="{loc:StringResource Key='BackupInterval_Label'}" />
-                    <ComboBox ItemsSource="{Binding BackupIntervals}" SelectedItem="{Binding SelectedBackupInterval, Mode=TwoWay}" MinWidth="200">
-                        <ComboBox.ItemTemplate>
-                            <DataTemplate>
-                                <StackPanel Orientation="Horizontal" Spacing="5">
-                                    <TextBlock Text="{Binding}" />
-                                    <TextBlock Text="{loc:StringResource Key='Minute(-s)'}" />
+                    <toolkit:SettingsExpander.Items>
+                        <StackPanel Spacing="16" Padding="20,10,20,20">
+                            <!-- Path Row -->
+                            <Grid ColumnSpacing="12">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <StackPanel>
+                                    <TextBlock Text="{loc:StringResource Key='BackupPath_Label'}" Margin="0,0,0,4"/>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBox Text="{Binding BackupPath, Mode=TwoWay}" IsReadOnly="True" Margin="0,0,8,0"/>
+                                        <Button Grid.Column="1" Content="{loc:StringResource Key='Browse_Button'}" Command="{Binding BrowseBackupPathCommand}"/>
+                                    </Grid>
+                                    <StackPanel Orientation="Horizontal" Spacing="10" Margin="0,8,0,0">
+                                        <Button Content="{loc:StringResource Key='DefaultPath_Button'}" Command="{Binding SetDefaultBackupPathCommand}" FontSize="12"/>
+                                        <Button Content="{loc:StringResource Key='OpenFolder_Button'}" Command="{Binding OpenBackupFolderCommand}" FontSize="12"/>
+                                    </StackPanel>
                                 </StackPanel>
-                            </DataTemplate>
-                        </ComboBox.ItemTemplate>
-                    </ComboBox>
+                            </Grid>
 
-                    <!-- Personal Backup Password -->
-                    <TextBlock Margin="0,15,0,5" Text="{loc:StringResource Key='BackupPassword_Label'}" />
-                    <Grid ColumnSpacing="10">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <TextBox 
-                            Text="{Binding BackupPassword, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
-                            IsReadOnly="False" 
-                            PlaceholderText="Enter backup password (min 6 chars)" />
-                    </Grid>
-                    <TextBlock Text="{loc:StringResource Key='BackupPassword_Tooltip'}" 
-                               Style="{StaticResource CaptionTextBlockStyle}" 
-                               Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}" 
-                               Margin="0,5,0,0" 
-                               TextWrapping="Wrap"/>
+                            <MenuFlyoutSeparator />
 
-                    <!-- Actions -->
-                    <StackPanel Orientation="Horizontal" Spacing="10" Margin="0,20,0,20">
-                        <Button Content="{loc:StringResource Key='SaveChanges'}" Style="{StaticResource AccentButtonStyle}" Command="{Binding SaveBackupSettingsCommand}" />
-                        <Button Content="{loc:StringResource Key='Cancel'}" Command="{Binding CancelBackupChangesCommand}" />
-                    </StackPanel>
-                </StackPanel>
+                            <!-- Settings Row -->
+                            <Grid ColumnSpacing="20">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
 
-                <!-- About Section -->
-                <StackPanel Margin="{StaticResource ControlSectionMargin}">
-                    <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text="{loc:StringResource Key=AboutApp}" />
+                                <!-- Frequency -->
+                                <StackPanel>
+                                    <TextBlock Text="{loc:StringResource Key='BackupInterval_Label'}" Margin="0,0,0,4"/>
+                                    <ComboBox ItemsSource="{Binding BackupIntervals}" SelectedItem="{Binding SelectedBackupInterval, Mode=TwoWay}" HorizontalAlignment="Stretch">
+                                        <ComboBox.ItemTemplate>
+                                            <DataTemplate>
+                                                <TextBlock><Run Text="{Binding}"/> <Run Text="{loc:StringResource Key='Minute(-s)'}"/></TextBlock>
+                                            </DataTemplate>
+                                        </ComboBox.ItemTemplate>
+                                    </ComboBox>
+                                </StackPanel>
 
-                    <Button 
-                        Margin="0,10,0,0" 
-                        Content="Report a Bug" 
-                        Click="BugRequestCard_Click" 
-                        HorizontalAlignment="Stretch"/>
+                                <!-- Retention -->
+                                <StackPanel Grid.Column="1">
+                                    <TextBlock Text="{loc:StringResource Key='BackupRetention_Label'}" Margin="0,0,0,4"/>
+                                    <ComboBox SelectedItem="{Binding RetentionDays, Mode=TwoWay}" HorizontalAlignment="Stretch">
+                                        <x:Int32>1</x:Int32>
+                                        <x:Int32>7</x:Int32>
+                                        <x:Int32>14</x:Int32>
+                                        <x:Int32>28</x:Int32>
+                                    </ComboBox>
+                                    <TextBlock Text="{loc:StringResource Key='Day(-s)'}" Style="{StaticResource CaptionTextBlockStyle}" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Margin="0,2,0,0"/>
+                                </StackPanel>
+                            </Grid>
 
-                    <StackPanel Margin="0,10,0,0" Orientation="Horizontal">
-                        <TextBlock Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}" Text="{loc:StringResource Key=Version}" />
-                        <TextBlock
-                            Margin="5,0,0,0"
-                            Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
-                            Text="{x:Bind viewmodels:SettingsViewModel.Version}" />
-                    </StackPanel>
-                </StackPanel>
+                            <MenuFlyoutSeparator />
+
+                            <!-- Password Row -->
+                            <StackPanel>
+                                <TextBlock Text="{loc:StringResource Key='BackupPassword_Label'}" Margin="0,0,0,4"/>
+                                <Grid ColumnSpacing="10">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBox Text="{Binding BackupPassword, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsSpellCheckEnabled="False"/>
+                                    <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10">
+                                        <Button Content="{loc:StringResource Key='SaveChanges'}" Style="{StaticResource AccentButtonStyle}" Command="{Binding SaveBackupSettingsCommand}"/>
+                                        <Button Content="{loc:StringResource Key='Cancel'}" Command="{Binding CancelBackupChangesCommand}"/>
+                                    </StackPanel>
+                                </Grid>
+                                <TextBlock Text="{loc:StringResource Key='BackupPassword_Tooltip'}" Style="{StaticResource CaptionTextBlockStyle}" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Margin="0,4,0,0"/>
+                            </StackPanel>
+
+                        </StackPanel>
+                    </toolkit:SettingsExpander.Items>
+                </toolkit:SettingsExpander>
+
+                <!-- Import Section -->
+                <TextBlock Text="{loc:StringResource Key='ImportSettings_Header'}"
+                           Style="{StaticResource SectionSubtitleTextBlockStyle}"/>
+
+                <toolkit:SettingsCard Margin="{StaticResource ControlSectionMargin}" 
+                                      Header="{loc:StringResource Key='ImportDestination_Label'}"
+                                      Description="{loc:StringResource Key='ImportDestination_Description'}">
+                    <ComboBox DisplayMemberPath="Content"
+                              ItemsSource="{Binding ImportDestinationOptions}"
+                              SelectedItem="{Binding SelectedImportDestination, Mode=TwoWay}"
+                              MinWidth="200"/>
+                </toolkit:SettingsCard>
+
+                <!-- Other Sections -->
+                <TextBlock Text="{loc:StringResource Key='Language'}" Style="{StaticResource SectionSubtitleTextBlockStyle}"/>
+                <toolkit:SettingsCard Margin="{StaticResource ControlSectionMargin}" Header="{loc:StringResource Key='ChooseApplicationLanguage'}">
+                    <ComboBox DisplayMemberPath="Name" SelectedValuePath="Name" ItemsSource="{Binding Languages}" SelectedItem="{Binding SelectedLanguage, Mode=TwoWay}" MinWidth="200"/>
+                </toolkit:SettingsCard>
+
+                <TextBlock Text="{loc:StringResource Key='Appearance'}" Style="{StaticResource SectionSubtitleTextBlockStyle}"/>
+                <toolkit:SettingsCard Header="{loc:StringResource Key='Theme'}" Margin="{StaticResource ControlSectionMargin}">
+                    <ComboBox DisplayMemberPath="Name" SelectedValuePath="Name" ItemsSource="{Binding AppThemes}" SelectedItem="{Binding SelectedAppTheme, Mode=TwoWay}" MinWidth="200"/>
+                </toolkit:SettingsCard>
+
+                <TextBlock Text="{loc:StringResource Key='Other'}" Style="{StaticResource SectionSubtitleTextBlockStyle}"/>
+                <toolkit:SettingsCard Margin="{StaticResource ControlSectionMargin}" Header="{loc:StringResource Key='LaunchAtStartup'}">
+                    <ToggleSwitch IsOn="{Binding AllowLaunchAtStartup}" OnContent="{loc:StringResource Key='ToggleSwitch_On'}" OffContent="{loc:StringResource Key='ToggleSwitch_Off'}"/>
+                </toolkit:SettingsCard>
+
+                <TextBlock Text="{loc:StringResource Key=AboutApp}" Style="{StaticResource SectionSubtitleTextBlockStyle}"/>
+                <toolkit:SettingsExpander Header="{StaticResource AppTitleName}" Margin="{StaticResource ControlSectionMargin}" Description="{loc:StringResource Key='Copyright_Description'}">
+                    <toolkit:SettingsExpander.HeaderIcon>
+                        <BitmapIcon ShowAsMonochrome="False" UriSource="/Assets/StoreLogo.scale-400.png" />
+                    </toolkit:SettingsExpander.HeaderIcon>
+                    <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" IsTextSelectionEnabled="True" Text="{Binding Version}" />
+                    <toolkit:SettingsExpander.Items>
+                        <toolkit:SettingsCard x:Name="bugRequestCard" Click="BugRequestCard_Click" Header="{loc:StringResource Key='BugRequest_Header'}" IsClickEnabled="True">
+                            <toolkit:SettingsCard.ActionIcon>
+                                <FontIcon Glyph="&#xE8A7;" />
+                            </toolkit:SettingsCard.ActionIcon>
+                        </toolkit:SettingsCard>
+                    </toolkit:SettingsExpander.Items>
+                </toolkit:SettingsExpander>
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/SettingsView.xaml
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/SettingsView.xaml
@@ -22,91 +22,142 @@
         <TextBlock Text="{loc:StringResource Key='Settings'}"
                    Style="{StaticResource HeaderTextBlockStyle}"/>
 
+        <!-- Content -->
         <ScrollViewer Grid.Row="1">
-            <StackPanel Orientation="Vertical">
-                <!--Security Section-->
-                <StackPanel Orientation="Vertical">
-                    <TextBlock Text="{loc:StringResource Key='Security'}"
-                               Style="{StaticResource SectionSubtitleTextBlockStyle}"/>
-                    <StackPanel Orientation="Vertical"
-                                Margin="{StaticResource ControlSectionMargin}">
-                        <toolkit:SettingsCard Header="{loc:StringResource Key='Autolock'}"
-                                              Description="{loc:StringResource Key='AutolockDescription'}">
-                            <ToggleSwitch IsOn="{Binding AllowAutolock, Mode=TwoWay}"/>
-                        </toolkit:SettingsCard>
-                        <toolkit:SettingsCard Margin="0 4 0 0" 
-                                              Header="{loc:StringResource Key='AutolockAfterMinutes'}"
-                                              Visibility="{Binding AllowAutolock, Converter={StaticResource BoolToVisibilityConvereter}}">
-                            <ComboBox DisplayMemberPath="Value"
-                                      SelectedValuePath="Value"
-                                      ItemsSource="{Binding LockOnIdleInMinutesItems}"
-                                      SelectedItem="{Binding SelectedLockOnIdleInMinutesItem, Mode=TwoWay}"/>
-                        </toolkit:SettingsCard>
+            <StackPanel Margin="{StaticResource PageContentContainerMargin}" Spacing="20">
+
+                <!-- Language Section -->
+                <StackPanel Margin="{StaticResource ControlSectionMargin}">
+                    <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text="{loc:StringResource Key=Language}" />
+                    <TextBlock
+                        Margin="0,10,0,5"
+                        Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
+                        Text="{loc:StringResource Key=ChooseApplicationLanguage}" />
+                    <ComboBox
+                        MinWidth="200"
+                        DisplayMemberPath="Name"
+                        ItemsSource="{Binding Languages}"
+                        SelectedItem="{Binding SelectedLanguage, Mode=TwoWay}" />
+                </StackPanel>
+
+                <!-- Appearance Section -->
+                <StackPanel Margin="{StaticResource ControlSectionMargin}">
+                    <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text="{loc:StringResource Key=Appearance}" />
+                    <TextBlock
+                        Margin="0,10,0,5"
+                        Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
+                        Text="{loc:StringResource Key=Theme}" />
+                    <ComboBox
+                        MinWidth="200"
+                        DisplayMemberPath="Name"
+                        ItemsSource="{Binding AppThemes}"
+                        SelectedItem="{Binding SelectedAppTheme, Mode=TwoWay}" />
+                </StackPanel>
+
+                <!-- Security Section -->
+                <StackPanel Margin="{StaticResource ControlSectionMargin}">
+                    <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text="{loc:StringResource Key=Security}" />
+                    <ToggleSwitch
+                        Margin="0,10,0,0"
+                        Header="{loc:StringResource Key=Autolock}"
+                        IsOn="{Binding AllowAutolock, Mode=TwoWay}" />
+                    <TextBlock
+                        Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="{loc:StringResource Key=AutolockDescription}" />
+
+                    <StackPanel Visibility="{Binding AllowAutolock, Converter={StaticResource BoolToVisibilityConvereter}}">
+                        <TextBlock Margin="0,10,0,5" Text="{loc:StringResource Key=AutolockAfterMinutes}" />
+                        <ComboBox
+                            MinWidth="200"
+                            DisplayMemberPath="Value"
+                            ItemsSource="{Binding LockOnIdleInMinutesItems}"
+                            SelectedItem="{Binding SelectedLockOnIdleInMinutesItem, Mode=TwoWay}" />
                     </StackPanel>
                 </StackPanel>
 
-                <!--Language Section-->
-                <StackPanel Orientation="Vertical">
-                    <TextBlock Text="{loc:StringResource Key='Language'}"
-                               Style="{StaticResource SectionSubtitleTextBlockStyle}"/>
-                    <toolkit:SettingsCard Margin="{StaticResource ControlSectionMargin}"
-                                          Header="{loc:StringResource Key='ChooseApplicationLanguage'}">
-                        <ComboBox DisplayMemberPath="Name"
-                                  SelectedValuePath="Name"
-                                  ItemsSource="{Binding Languages}"
-                                  SelectedItem="{Binding SelectedLanguage, Mode=TwoWay}"/>
-                    </toolkit:SettingsCard>
-                </StackPanel>
+                <!-- BACKUP SECTION -->
+                <StackPanel Margin="{StaticResource ControlSectionMargin}">
+                    <TextBlock Text="{loc:StringResource Key='BackupSettings_Header'}" Style="{StaticResource SubtitleTextBlockStyle}" />
 
-                <!--Appearance Section-->
-                <StackPanel Orientation="Vertical">
-                    <TextBlock Text="{loc:StringResource Key='Appearance'}"
-                               Style="{StaticResource SectionSubtitleTextBlockStyle}"/>
-                    <toolkit:SettingsCard Header="{loc:StringResource Key='Theme'}"
-                                          Margin="{StaticResource ControlSectionMargin}">
-                        <ComboBox DisplayMemberPath="Name"
-                                  SelectedValuePath="Name"
-                                  ItemsSource="{Binding AppThemes}"
-                                  SelectedItem="{Binding SelectedAppTheme, Mode=TwoWay}"/>
-                    </toolkit:SettingsCard>
-                </StackPanel>
+                    <!-- Service Toggle -->
+                    <ToggleSwitch 
+                        Margin="0,10,0,0"
+                        IsOn="{Binding IsBackupServiceEnabled, Mode=TwoWay}" 
+                        Header="{loc:StringResource Key='BackupService_Toggle'}"/>
 
-                <!--Other Section-->
-                <StackPanel Orientation="Vertical">
-                    <StackPanel Orientation="Vertical">
-                        <TextBlock Text="{loc:StringResource Key='Other'}"
-                                   Style="{StaticResource SectionSubtitleTextBlockStyle}"/>
-                        <toolkit:SettingsCard Margin="{StaticResource ControlSectionMargin}"
-                                              Header="{loc:StringResource Key='LaunchAtStartup'}">
-                            <ToggleSwitch IsOn="{Binding AllowLaunchAtStartup}"/>
-                        </toolkit:SettingsCard>
+                    <!-- Path Selection -->
+                    <TextBlock Margin="0,15,0,5" Text="{loc:StringResource Key='BackupPath_Label'}" />
+                    <Grid ColumnSpacing="10">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBox Text="{Binding BackupPath, Mode=TwoWay}" IsReadOnly="True" />
+                        <Button Grid.Column="1" Content="{loc:StringResource Key='Browse_Button'}" Command="{Binding BrowseBackupPathCommand}" />
+                    </Grid>
+
+                    <!-- Path Buttons -->
+                    <StackPanel Orientation="Horizontal" Spacing="10" Margin="0,10,0,0">
+                        <Button Content="{loc:StringResource Key='DefaultPath_Button'}" Command="{Binding SetDefaultBackupPathCommand}" />
+                        <Button Content="{loc:StringResource Key='OpenFolder_Button'}" Command="{Binding OpenBackupFolderCommand}" />
+                    </StackPanel>
+
+                    <!-- Frequency -->
+                    <TextBlock Margin="0,15,0,5" Text="{loc:StringResource Key='BackupInterval_Label'}" />
+                    <ComboBox ItemsSource="{Binding BackupIntervals}" SelectedItem="{Binding SelectedBackupInterval, Mode=TwoWay}" MinWidth="200">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Horizontal" Spacing="5">
+                                    <TextBlock Text="{Binding}" />
+                                    <TextBlock Text="{loc:StringResource Key='Minute(-s)'}" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+
+                    <!-- Personal Backup Password -->
+                    <TextBlock Margin="0,15,0,5" Text="{loc:StringResource Key='BackupPassword_Label'}" />
+                    <Grid ColumnSpacing="10">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBox 
+                            Text="{Binding BackupPassword, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                            IsReadOnly="False" 
+                            PlaceholderText="Enter backup password (min 6 chars)" />
+                    </Grid>
+                    <TextBlock Text="{loc:StringResource Key='BackupPassword_Tooltip'}" 
+                               Style="{StaticResource CaptionTextBlockStyle}" 
+                               Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}" 
+                               Margin="0,5,0,0" 
+                               TextWrapping="Wrap"/>
+
+                    <!-- Actions -->
+                    <StackPanel Orientation="Horizontal" Spacing="10" Margin="0,20,0,20">
+                        <Button Content="{loc:StringResource Key='SaveChanges'}" Style="{StaticResource AccentButtonStyle}" Command="{Binding SaveBackupSettingsCommand}" />
+                        <Button Content="{loc:StringResource Key='Cancel'}" Command="{Binding CancelBackupChangesCommand}" />
                     </StackPanel>
                 </StackPanel>
 
-                <StackPanel Orientation="Vertical"
-                            Margin="0 0 0 40">
-                    <TextBlock Text="{loc:StringResource Key=AboutApp}"
-                               Style="{StaticResource SectionSubtitleTextBlockStyle}"/>
-                    <toolkit:SettingsExpander Header="{StaticResource AppTitleName}" 
-                                              Margin="{StaticResource ControlSectionMargin}"
-                                              Description="© 2024 Cats Lab. All rights reserved.">
-                        <toolkit:SettingsExpander.HeaderIcon>
-                            <BitmapIcon ShowAsMonochrome="False" UriSource="/Assets/StoreLogo.scale-400.png" />
-                        </toolkit:SettingsExpander.HeaderIcon>
-                        <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                   IsTextSelectionEnabled="True"
-                                   Text="{Binding Version}" />
-                        <toolkit:SettingsExpander.Items>
-                            <toolkit:SettingsCard x:Name="bugRequestCard"
-                                                  Click="BugRequestCard_Click"
-                                                  Header="File a bug or request new sample"
-                                                  IsClickEnabled="True">
-                                <toolkit:SettingsCard.ActionIcon>
-                                    <FontIcon Glyph="&#xE8A7;" />
-                                </toolkit:SettingsCard.ActionIcon>
-                            </toolkit:SettingsCard>
-                        </toolkit:SettingsExpander.Items>
-                    </toolkit:SettingsExpander>
+                <!-- About Section -->
+                <StackPanel Margin="{StaticResource ControlSectionMargin}">
+                    <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text="{loc:StringResource Key=AboutApp}" />
+
+                    <Button 
+                        Margin="0,10,0,0" 
+                        Content="Report a Bug" 
+                        Click="BugRequestCard_Click" 
+                        HorizontalAlignment="Stretch"/>
+
+                    <StackPanel Margin="0,10,0,0" Orientation="Horizontal">
+                        <TextBlock Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}" Text="{loc:StringResource Key=Version}" />
+                        <TextBlock
+                            Margin="5,0,0,0"
+                            Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
+                            Text="{x:Bind viewmodels:SettingsViewModel.Version}" />
+                    </StackPanel>
                 </StackPanel>
             </StackPanel>
         </ScrollViewer>

--- a/src/Services/Pango.BackupService/Pango.BackupService.csproj
+++ b/src/Services/Pango.BackupService/Pango.BackupService.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OutputType>WinExe</OutputType>
-	<UseWindowsForms>true</UseWindowsForms>
+	<UseWindowsForms>True</UseWindowsForms>
 	<UserSecretsId>dotnet-Pango.BackupService-e78251c5-4aeb-4998-8d62-af1514f27016</UserSecretsId>
   </PropertyGroup>
 

--- a/src/Services/Pango.BackupService/Pango.BackupService.csproj
+++ b/src/Services/Pango.BackupService/Pango.BackupService.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <OutputType>WinExe</OutputType>
+	<UseWindowsForms>true</UseWindowsForms>
+	<UserSecretsId>dotnet-Pango.BackupService-e78251c5-4aeb-4998-8d62-af1514f27016</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Pango.Application\Pango.Application.csproj" />
+    <ProjectReference Include="..\..\Infrastructure\Pango.Infrastructure\Pango.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Services/Pango.BackupService/Program.cs
+++ b/src/Services/Pango.BackupService/Program.cs
@@ -1,0 +1,27 @@
+using Pango.Application.Common.Interfaces.Services;
+using Pango.BackupService;
+using Pango.Infrastructure.Services;
+using System.Runtime.InteropServices;
+
+if (OperatingSystem.IsWindows())
+{
+    var handle = GetConsoleWindow();
+    ShowWindow(handle, 0);
+}
+
+IHost host = Host.CreateDefaultBuilder(args)
+    .UseWindowsService()
+    .ConfigureServices(services =>
+    {
+        services.AddSingleton<IBackupManager, BackupManager>();
+        services.AddHostedService<Worker>();
+    })
+    .Build();
+
+await host.RunAsync();
+
+[DllImport("kernel32.dll")]
+static extern IntPtr GetConsoleWindow();
+
+[DllImport("user32.dll")]
+static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);

--- a/src/Services/Pango.BackupService/Properties/launchSettings.json
+++ b/src/Services/Pango.BackupService/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "Pango.BackupService": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Services/Pango.BackupService/Worker.cs
+++ b/src/Services/Pango.BackupService/Worker.cs
@@ -1,6 +1,5 @@
 using Pango.Application.Common;
 using Pango.Application.Common.Interfaces.Services;
-using Pango.Infrastructure.Services;
 using System.Text.Json;
 
 namespace Pango.BackupService;
@@ -11,24 +10,18 @@ public class Worker : BackgroundService
     private readonly IBackupManager _backupManager;
     private readonly string _configPath;
 
-    // Path where UWP app stores user data (LocalState/users)
-    private readonly string _appDataRoot;
-
+    // Constructor initializes logger, manager and paths
     public Worker(ILogger<Worker> logger, IBackupManager backupManager)
     {
         _logger = logger;
         _backupManager = backupManager;
 
-        // Path to the shared config file in ProgramData
+        // Path to config in ProgramData (accessible by Service)
         string commonAppData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
         _configPath = Path.Combine(commonAppData, "Pango", "backup_config.json");
-
-        // Construct path to the UWP LocalState/users folder
-        string userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        _appDataRoot = Path.Combine(userProfile, "AppData", "Local", "Packages", "Pango_p2sx85d", "LocalState", "users");
     }
 
-    // Main execution loop of the Windows Service
+    // Main service loop executing background tasks
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         while (!stoppingToken.IsCancellationRequested)
@@ -42,33 +35,35 @@ public class Worker : BackgroundService
                     string userId = userEntry.Key;
                     UserBackupProfile profile = userEntry.Value;
 
+                    // Skip if source path is invalid
                     if (string.IsNullOrEmpty(profile.SourceDataPath) || !Directory.Exists(profile.SourceDataPath))
                     {
-                        _logger.LogWarning("Source path for user {User} is invalid or empty. Run the App to configure.", userId);
+                        _logger.LogWarning("Invalid source path for user {User}", userId);
                         continue;
                     }
 
-                    if (_backupManager is BackupManager manager)
-                    {
-                        await manager.PerformBackupForUserAsync(
-                            userId,
-                            profile.SourceDataPath,
-                            settings.TargetFolderPath,
-                            profile.BackupPassword);
-                    }
+                    // Execute backup logic
+                    await _backupManager.PerformBackupForUserAsync(
+                        userId,
+                        profile.SourceDataPath,
+                        settings.TargetFolderPath,
+                        profile.BackupPassword,
+                        settings.RetentionDays > 0 ? settings.RetentionDays : 7);
                 }
 
+                // Wait for the next cycle
                 int interval = settings.IntervalMinutes > 0 ? settings.IntervalMinutes : 60;
                 await Task.Delay(TimeSpan.FromMinutes(interval), stoppingToken);
             }
             else
             {
+                // Retry shortly if no settings found
                 await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
             }
         }
     }
 
-    // Reads the JSON configuration file from disk
+    // Helper to read configuration from disk
     private BackupSettings? LoadSettings()
     {
         try
@@ -81,7 +76,7 @@ public class Worker : BackgroundService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to load backup configuration from {Path}", _configPath);
+            _logger.LogError(ex, "Config load failed: {Path}", _configPath);
         }
         return null;
     }

--- a/src/Services/Pango.BackupService/Worker.cs
+++ b/src/Services/Pango.BackupService/Worker.cs
@@ -1,0 +1,88 @@
+using Pango.Application.Common;
+using Pango.Application.Common.Interfaces.Services;
+using Pango.Infrastructure.Services;
+using System.Text.Json;
+
+namespace Pango.BackupService;
+
+public class Worker : BackgroundService
+{
+    private readonly ILogger<Worker> _logger;
+    private readonly IBackupManager _backupManager;
+    private readonly string _configPath;
+
+    // Path where UWP app stores user data (LocalState/users)
+    private readonly string _appDataRoot;
+
+    public Worker(ILogger<Worker> logger, IBackupManager backupManager)
+    {
+        _logger = logger;
+        _backupManager = backupManager;
+
+        // Path to the shared config file in ProgramData
+        string commonAppData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+        _configPath = Path.Combine(commonAppData, "Pango", "backup_config.json");
+
+        // Construct path to the UWP LocalState/users folder
+        string userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        _appDataRoot = Path.Combine(userProfile, "AppData", "Local", "Packages", "Pango_p2sx85d", "LocalState", "users");
+    }
+
+    // Main execution loop of the Windows Service
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var settings = LoadSettings();
+
+            if (settings != null && settings.IsEnabled && settings.Users != null)
+            {
+                foreach (var userEntry in settings.Users)
+                {
+                    string userId = userEntry.Key;
+                    UserBackupProfile profile = userEntry.Value;
+
+                    if (string.IsNullOrEmpty(profile.SourceDataPath) || !Directory.Exists(profile.SourceDataPath))
+                    {
+                        _logger.LogWarning("Source path for user {User} is invalid or empty. Run the App to configure.", userId);
+                        continue;
+                    }
+
+                    if (_backupManager is BackupManager manager)
+                    {
+                        await manager.PerformBackupForUserAsync(
+                            userId,
+                            profile.SourceDataPath,
+                            settings.TargetFolderPath,
+                            profile.BackupPassword);
+                    }
+                }
+
+                int interval = settings.IntervalMinutes > 0 ? settings.IntervalMinutes : 60;
+                await Task.Delay(TimeSpan.FromMinutes(interval), stoppingToken);
+            }
+            else
+            {
+                await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
+            }
+        }
+    }
+
+    // Reads the JSON configuration file from disk
+    private BackupSettings? LoadSettings()
+    {
+        try
+        {
+            if (File.Exists(_configPath))
+            {
+                string json = File.ReadAllText(_configPath);
+                return JsonSerializer.Deserialize<BackupSettings>(json);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load backup configuration from {Path}", _configPath);
+        }
+        return null;
+    }
+}

--- a/src/Services/Pango.BackupService/appsettings.Development.json
+++ b/src/Services/Pango.BackupService/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/src/Services/Pango.BackupService/appsettings.json
+++ b/src/Services/Pango.BackupService/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/tests/Pango.Infrastructure.Tests/BackupRotationTests.cs
+++ b/tests/Pango.Infrastructure.Tests/BackupRotationTests.cs
@@ -1,0 +1,123 @@
+﻿using Microsoft.Extensions.Logging;
+using Moq;
+using Pango.Infrastructure.Services;
+
+namespace Pango.Tests.Infrastructure;
+
+public class BackupRotationTests : IDisposable
+{
+    private readonly string _testTargetDir;
+    private readonly string _testSourceDir;
+    private readonly BackupManager _manager;
+    private readonly Mock<ILogger<BackupManager>> _loggerMock;
+
+    // Constructor acts as Setup in xUnit
+    public BackupRotationTests()
+    {
+        _testTargetDir = Path.Combine(Path.GetTempPath(), "Pango_Target_" + Guid.NewGuid());
+        _testSourceDir = Path.Combine(Path.GetTempPath(), "Pango_Source_" + Guid.NewGuid());
+
+        Directory.CreateDirectory(_testTargetDir);
+        Directory.CreateDirectory(_testSourceDir);
+
+        // Create a dummy file in source to zip and encrypt
+        File.WriteAllText(Path.Combine(_testSourceDir, "data.txt"), "Sensitive Content");
+
+        _loggerMock = new Mock<ILogger<BackupManager>>();
+        _manager = new BackupManager(_loggerMock.Object);
+    }
+
+    // Dispose acts as TearDown in xUnit
+    public void Dispose()
+    {
+        if (Directory.Exists(_testTargetDir)) Directory.Delete(_testTargetDir, true);
+        if (Directory.Exists(_testSourceDir)) Directory.Delete(_testSourceDir, true);
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task PerformBackupForUser_ShouldCreateEncryptedFile()
+    {
+        // Arrange
+        string userId = "TestUser";
+        string password = "TestPassword";
+
+        // Act
+        await _manager.PerformBackupForUserAsync(userId, _testSourceDir, _testTargetDir, password);
+
+        // Assert
+        string date = DateTime.Now.ToString("yyyy-MM-dd");
+        string expectedFile = Path.Combine(_testTargetDir, $"{date}-{userId}_Backup.pngx");
+
+        Assert.True(File.Exists(expectedFile));
+
+        // Ensure file is not empty
+        var fileInfo = new FileInfo(expectedFile);
+        Assert.True(fileInfo.Length > 0);
+    }
+
+    [Fact]
+    public async Task PerformBackupForUser_ShouldRotateMaxThreeFiles()
+    {
+        // Arrange
+        string userId = "TestUser";
+        string password = "TestPassword";
+        string date = DateTime.Now.ToString("yyyy-MM-dd");
+
+        string baseFile = Path.Combine(_testTargetDir, $"{date}-{userId}_Backup.pngx");
+        string file1 = Path.Combine(_testTargetDir, $"{date}-{userId}_Backup1.pngx");
+        string file2 = Path.Combine(_testTargetDir, $"{date}-{userId}_Backup2.pngx");
+
+        // Act & Assert 1: First backup
+        await _manager.PerformBackupForUserAsync(userId, _testSourceDir, _testTargetDir, password);
+        Assert.True(File.Exists(baseFile));
+        Assert.False(File.Exists(file1));
+
+        // Act & Assert 2: Second backup (should move base to 1)
+        await Task.Delay(50);
+        await _manager.PerformBackupForUserAsync(userId, _testSourceDir, _testTargetDir, password);
+        Assert.True(File.Exists(baseFile));
+        Assert.True(File.Exists(file1));
+        Assert.False(File.Exists(file2));
+
+        // Act & Assert 3: Third backup (should fill 2)
+        await Task.Delay(50);
+        await _manager.PerformBackupForUserAsync(userId, _testSourceDir, _testTargetDir, password);
+        Assert.True(File.Exists(baseFile));
+        Assert.True(File.Exists(file1));
+        Assert.True(File.Exists(file2));
+    }
+
+    [Fact]
+    public async Task CleanUpOldBackups_ShouldKeepOnlyLatestOfYesterday()
+    {
+        // Arrange
+        string userId = "CleanupUser";
+        string oldDate = "2023-01-01";
+
+        // Simulate 3 files from a past date
+        string f1 = Path.Combine(_testTargetDir, $"{oldDate}-{userId}_Backup.pngx");
+        string f2 = Path.Combine(_testTargetDir, $"{oldDate}-{userId}_Backup1.pngx");
+        string f3 = Path.Combine(_testTargetDir, $"{oldDate}-{userId}_Backup2.pngx");
+
+        File.Create(f1).Close();
+        await Task.Delay(20);
+        File.Create(f2).Close();
+        await Task.Delay(20);
+        File.Create(f3).Close();
+
+        // Force WriteTime to verify logic relies on timestamp, not just name
+        File.SetLastWriteTime(f1, DateTime.Now.AddDays(-10));
+        File.SetLastWriteTime(f2, DateTime.Now.AddDays(-9));
+        File.SetLastWriteTime(f3, DateTime.Now.AddDays(-8));
+
+        // Act
+        await _manager.CleanUpOldBackupsAsync(_testTargetDir, userId);
+
+        // Assert
+        var files = Directory.GetFiles(_testTargetDir);
+
+        Assert.Single(files);
+        Assert.Equal(f3, files[0]);
+    }
+}

--- a/tests/Pango.Infrastructure.Tests/BackupRotationTests.cs
+++ b/tests/Pango.Infrastructure.Tests/BackupRotationTests.cs
@@ -1,123 +1,135 @@
 ﻿using Microsoft.Extensions.Logging;
 using Moq;
 using Pango.Infrastructure.Services;
+using System.Runtime.Versioning;
 
-namespace Pango.Tests.Infrastructure;
+namespace Pango.Tests;
 
+[SupportedOSPlatform("windows")]
 public class BackupRotationTests : IDisposable
 {
-    private readonly string _testTargetDir;
-    private readonly string _testSourceDir;
-    private readonly BackupManager _manager;
-    private readonly Mock<ILogger<BackupManager>> _loggerMock;
+    private readonly string _testBackupFolder;
+    private readonly Mock<ILogger<BackupManager>> _mockLogger;
+    private readonly BackupManager _backupManager;
+    private const string TestUser = "testuser";
 
-    // Constructor acts as Setup in xUnit
+    // Sets up the test environment and creates a temp directory
     public BackupRotationTests()
     {
-        _testTargetDir = Path.Combine(Path.GetTempPath(), "Pango_Target_" + Guid.NewGuid());
-        _testSourceDir = Path.Combine(Path.GetTempPath(), "Pango_Source_" + Guid.NewGuid());
+        _testBackupFolder = Path.Combine(Path.GetTempPath(), "PangoBackupTests_" + Guid.NewGuid());
+        Directory.CreateDirectory(_testBackupFolder);
 
-        Directory.CreateDirectory(_testTargetDir);
-        Directory.CreateDirectory(_testSourceDir);
-
-        // Create a dummy file in source to zip and encrypt
-        File.WriteAllText(Path.Combine(_testSourceDir, "data.txt"), "Sensitive Content");
-
-        _loggerMock = new Mock<ILogger<BackupManager>>();
-        _manager = new BackupManager(_loggerMock.Object);
+        _mockLogger = new Mock<ILogger<BackupManager>>();
+        _backupManager = new BackupManager(_mockLogger.Object);
     }
 
-    // Dispose acts as TearDown in xUnit
+    // Cleans up the temp directory after tests
     public void Dispose()
     {
-        if (Directory.Exists(_testTargetDir)) Directory.Delete(_testTargetDir, true);
-        if (Directory.Exists(_testSourceDir)) Directory.Delete(_testSourceDir, true);
+        if (Directory.Exists(_testBackupFolder))
+        {
+            try { Directory.Delete(_testBackupFolder, true); } catch { }
+        }
         GC.SuppressFinalize(this);
     }
 
     [Fact]
-    public async Task PerformBackupForUser_ShouldCreateEncryptedFile()
+    // Verifies that files older than the retention period are deleted
+    public async Task CleanUpOldBackupsAsync_ShouldDeleteFiles_OlderThanRetentionDays()
     {
         // Arrange
-        string userId = "TestUser";
-        string password = "TestPassword";
+        int retentionDays = 7;
+        string oldFile = CreateDummyBackupFile(DateTime.Now.AddDays(-10)); // 10 days old
+        string newFile = CreateDummyBackupFile(DateTime.Now.AddDays(-2));  // 2 days old
+        string todayFile = CreateDummyBackupFile(DateTime.Now);
 
         // Act
-        await _manager.PerformBackupForUserAsync(userId, _testSourceDir, _testTargetDir, password);
+        await _backupManager.CleanUpOldBackupsAsync(_testBackupFolder, TestUser, retentionDays);
 
         // Assert
-        string date = DateTime.Now.ToString("yyyy-MM-dd");
-        string expectedFile = Path.Combine(_testTargetDir, $"{date}-{userId}_Backup.pngx");
-
-        Assert.True(File.Exists(expectedFile));
-
-        // Ensure file is not empty
-        var fileInfo = new FileInfo(expectedFile);
-        Assert.True(fileInfo.Length > 0);
+        Assert.False(File.Exists(oldFile), "Old file (> 7 days) should be deleted");
+        Assert.True(File.Exists(newFile), "New file (2 days) should exist");
+        Assert.True(File.Exists(todayFile), "Today's file should exist");
     }
 
     [Fact]
-    public async Task PerformBackupForUser_ShouldRotateMaxThreeFiles()
+    // Verifies that no files are deleted if infinite retention (0) is selected
+    public async Task CleanUpOldBackupsAsync_ShouldKeepAll_WhenRetentionIsZero()
     {
         // Arrange
-        string userId = "TestUser";
-        string password = "TestPassword";
-        string date = DateTime.Now.ToString("yyyy-MM-dd");
+        int retentionDays = 0; // Infinite
+        string veryOldFile = CreateDummyBackupFile(DateTime.Now.AddDays(-365));
 
-        string baseFile = Path.Combine(_testTargetDir, $"{date}-{userId}_Backup.pngx");
-        string file1 = Path.Combine(_testTargetDir, $"{date}-{userId}_Backup1.pngx");
-        string file2 = Path.Combine(_testTargetDir, $"{date}-{userId}_Backup2.pngx");
+        // Act
+        await _backupManager.CleanUpOldBackupsAsync(_testBackupFolder, TestUser, retentionDays);
 
-        // Act & Assert 1: First backup
-        await _manager.PerformBackupForUserAsync(userId, _testSourceDir, _testTargetDir, password);
-        Assert.True(File.Exists(baseFile));
-        Assert.False(File.Exists(file1));
-
-        // Act & Assert 2: Second backup (should move base to 1)
-        await Task.Delay(50);
-        await _manager.PerformBackupForUserAsync(userId, _testSourceDir, _testTargetDir, password);
-        Assert.True(File.Exists(baseFile));
-        Assert.True(File.Exists(file1));
-        Assert.False(File.Exists(file2));
-
-        // Act & Assert 3: Third backup (should fill 2)
-        await Task.Delay(50);
-        await _manager.PerformBackupForUserAsync(userId, _testSourceDir, _testTargetDir, password);
-        Assert.True(File.Exists(baseFile));
-        Assert.True(File.Exists(file1));
-        Assert.True(File.Exists(file2));
+        // Assert
+        Assert.True(File.Exists(veryOldFile), "File should be kept when retention is 0 (infinite)");
     }
 
     [Fact]
-    public async Task CleanUpOldBackups_ShouldKeepOnlyLatestOfYesterday()
+    // Verifies that files within the valid date range are preserved
+    public async Task CleanUpOldBackupsAsync_ShouldNotDelete_IfWithinRetentionPeriod()
     {
         // Arrange
-        string userId = "CleanupUser";
-        string oldDate = "2023-01-01";
-
-        // Simulate 3 files from a past date
-        string f1 = Path.Combine(_testTargetDir, $"{oldDate}-{userId}_Backup.pngx");
-        string f2 = Path.Combine(_testTargetDir, $"{oldDate}-{userId}_Backup1.pngx");
-        string f3 = Path.Combine(_testTargetDir, $"{oldDate}-{userId}_Backup2.pngx");
-
-        File.Create(f1).Close();
-        await Task.Delay(20);
-        File.Create(f2).Close();
-        await Task.Delay(20);
-        File.Create(f3).Close();
-
-        // Force WriteTime to verify logic relies on timestamp, not just name
-        File.SetLastWriteTime(f1, DateTime.Now.AddDays(-10));
-        File.SetLastWriteTime(f2, DateTime.Now.AddDays(-9));
-        File.SetLastWriteTime(f3, DateTime.Now.AddDays(-8));
+        int retentionDays = 30;
+        string file = CreateDummyBackupFile(DateTime.Now.AddDays(-20));
 
         // Act
-        await _manager.CleanUpOldBackupsAsync(_testTargetDir, userId);
+        await _backupManager.CleanUpOldBackupsAsync(_testBackupFolder, TestUser, retentionDays);
 
         // Assert
-        var files = Directory.GetFiles(_testTargetDir);
+        Assert.True(File.Exists(file), "File within retention period should not be deleted");
+    }
 
-        Assert.Single(files);
-        Assert.Equal(f3, files[0]);
+    [Fact]
+    // Verifies that random files or files from other users are ignored
+    public async Task CleanUpOldBackupsAsync_ShouldIgnore_NonBackupFiles()
+    {
+        // Arrange
+        string randomFile = Path.Combine(_testBackupFolder, "random.txt");
+        File.WriteAllText(randomFile, "data");
+
+        string wrongPattern = Path.Combine(_testBackupFolder, "2020-01-01-wronguser_Backup.pngx");
+        File.WriteAllText(wrongPattern, "data");
+
+        // Act
+        await _backupManager.CleanUpOldBackupsAsync(_testBackupFolder, TestUser, 5);
+
+        // Assert
+        Assert.True(File.Exists(randomFile), "Random text file should be ignored");
+        Assert.True(File.Exists(wrongPattern), "File with wrong user pattern should be ignored");
+    }
+
+    [Fact]
+    // Verifies behavior when file age exactly matches retention limit
+    public async Task CleanUpOldBackupsAsync_ShouldHandle_EdgeCase_ExactlyOnRetentionLimit()
+    {
+        // Arrange
+        int retentionDays = 5;
+        // 5 days minus 1 minute means it is NOT YET older than 5 days
+        string edgeFile = CreateDummyBackupFile(DateTime.Now.AddDays(-5).AddMinutes(1));
+
+        // Act
+        await _backupManager.CleanUpOldBackupsAsync(_testBackupFolder, TestUser, retentionDays);
+
+        // Assert
+        Assert.True(File.Exists(edgeFile), "File slightly inside retention limit should exist");
+    }
+
+    // Helper method to create a dummy file with a specific date in filename
+    private string CreateDummyBackupFile(DateTime date)
+    {
+        string timestamp = date.ToString("yyyy-MM-dd_HH-mm-ss");
+        string fileName = $"{timestamp}-{TestUser}_Backup.pngx";
+        string fullPath = Path.Combine(_testBackupFolder, fileName);
+
+        File.WriteAllText(fullPath, "dummy encrypted content");
+
+        // Update OS timestamps to match filename for consistency
+        File.SetCreationTime(fullPath, date);
+        File.SetLastWriteTime(fullPath, date);
+
+        return fullPath;
     }
 }

--- a/tests/Pango.Infrastructure.Tests/Pango.Infrastructure.Tests.csproj
+++ b/tests/Pango.Infrastructure.Tests/Pango.Infrastructure.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net6.0-windows10.0.19041.0;net7.0-windows10.0.19041.0</TargetFrameworks>

--- a/tests/Pango.Infrastructure.Tests/Pango.Infrastructure.Tests.csproj
+++ b/tests/Pango.Infrastructure.Tests/Pango.Infrastructure.Tests.csproj
@@ -12,6 +12,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
feat: Implement standalone backup service with settings UI integration
  - Created Pango.BackupService (Worker Service) to handle backups independently of the main app process.
  - Implemented full BackupManager logic in Infrastructure:
  - 3-file rotation strategy ({name}, {name}1, {name}2).
  - Daily cleanup retention policy (keeps only last backup of previous days).
  - Safe zipping of encrypted storage folder.
  - Integrated Backup Settings into existing SettingsView (UWP):
  - Added Path selection (Browse, Default, Open).
  - Added Interval configuration.
  - Implemented Save/Cancel logic using shared JSON config in ProgramData.
  - Updated Localization resources (en-US, be-BY) with full text coverage.
  - Added comprehensive unit tests for rotation and cleanup algorithms.
  - Added backup password field in settings with secure input and storage.
  - Fixed import functionality to correctly restore missing keys and folders.
refs: #40