### PR TITLE
Implementing generation logic

### DIFF
--- a/src/Core/Pango.Application/Common/AppConstants.cs
+++ b/src/Core/Pango.Application/Common/AppConstants.cs
@@ -8,4 +8,13 @@ public static class AppConstants
     public const int DefaultNumberOfItemsPerFile = 20;
 
     public const char CatalogDelimeter = '/';
+    /// <summary>
+    /// File extension used for exported data files.
+    /// </summary>
+    public const string ExportFileExtension = ".pngx";
+    /// <summary>
+    /// Default name of the subfolder used to store exported files
+    /// under the user's Documents directory.
+    /// </summary>
+    public const string DefaultExportFolderName = "PangoExports";
 }

--- a/src/Core/Pango.Application/Common/ApplicationErrors.cs
+++ b/src/Core/Pango.Application/Common/ApplicationErrors.cs
@@ -29,5 +29,7 @@ public static class ApplicationErrors
         public const string DeletionFailed = "Password.DeletionFailed";
         public const string CreationFailed = "Password.DeletionFailed";
         public const string ModificationFailed = "Password.ModificationFailed";
+        public const string GenerationInvalidLength = "Password.Generation.InvalidLength";
+        public const string GenerationInvalidCharsets = "Password.Generation.InvalidCharsets";
     }
 }

--- a/src/Core/Pango.Application/Common/Interfaces/Persistence/IPasswordGenerator.cs
+++ b/src/Core/Pango.Application/Common/Interfaces/Persistence/IPasswordGenerator.cs
@@ -1,0 +1,7 @@
+﻿namespace Pango.Application.Common.Interfaces.Persistence
+{
+    public interface IPasswordGenerator
+    {
+        Task<string> GeneratePassword(PasswordGenerationOptions options);
+    }
+}

--- a/src/Core/Pango.Application/Common/Interfaces/Persistence/IPasswordGenerator.cs
+++ b/src/Core/Pango.Application/Common/Interfaces/Persistence/IPasswordGenerator.cs
@@ -1,7 +1,6 @@
-﻿namespace Pango.Application.Common.Interfaces.Persistence
+﻿namespace Pango.Application.Common.Interfaces.Persistence;
+
+public interface IPasswordGenerator
 {
-    public interface IPasswordGenerator
-    {
-        Task<string> GeneratePassword(PasswordGenerationOptions options);
-    }
+    ValueTask<string> GeneratePasswordAsync(PasswordGenerationOptions options);
 }

--- a/src/Core/Pango.Application/Common/PasswordConstants.cs
+++ b/src/Core/Pango.Application/Common/PasswordConstants.cs
@@ -1,13 +1,12 @@
-﻿namespace Pango.Application.Common
+﻿namespace Pango.Application.Common;
+
+public class PasswordConstants
 {
-    public class PasswordConstants
-    {
-        public const int MinLength = 8;
-        public const int MaxLength = 64;
-        public const string Uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-        public const string Lowercase = "abcdefghijklmnopqrstuvwxyz";
-        public const string Digits = "0123456789";
-        public const string Special = "!@#$%^&*()-_=+[]{};:,.<>/?";
-        public const string Ambiguous = "0O1Il|";
-    }
+    public const int MinLength = 8;
+    public const int MaxLength = 64;
+    public const string Uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    public const string Lowercase = "abcdefghijklmnopqrstuvwxyz";
+    public const string Digits = "0123456789";
+    public const string Special = "!@#$%^&*()-_=+[]{};:,.<>/?";
+    public const string Ambiguous = "0O1Il|";
 }

--- a/src/Core/Pango.Application/Common/PasswordConstants.cs
+++ b/src/Core/Pango.Application/Common/PasswordConstants.cs
@@ -4,5 +4,10 @@
     {
         public const int MinLength = 8;
         public const int MaxLength = 64;
+        public const string Uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        public const string Lowercase = "abcdefghijklmnopqrstuvwxyz";
+        public const string Digits = "0123456789";
+        public const string Special = "!@#$%^&*()-_=+[]{};:,.<>/?";
+        public const string Ambiguous = "0O1Il|";
     }
 }

--- a/src/Core/Pango.Application/Common/PasswordConstants.cs
+++ b/src/Core/Pango.Application/Common/PasswordConstants.cs
@@ -1,0 +1,8 @@
+﻿namespace Pango.Application.Common
+{
+    public class PasswordConstants
+    {
+        public const int MinLength = 8;
+        public const int MaxLength = 64;
+    }
+}

--- a/src/Core/Pango.Application/Common/PasswordConstants.cs
+++ b/src/Core/Pango.Application/Common/PasswordConstants.cs
@@ -5,6 +5,8 @@ public class PasswordConstants
     public const int MinLength = 8;
     public const int MaxLength = 64;
     public const int SafeLength = 16;
+    public const int WeakThreshold = 3;
+    public const int MediumThreshold = 6;
     public const string Uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     public const string Lowercase = "abcdefghijklmnopqrstuvwxyz";
     public const string Digits = "0123456789";

--- a/src/Core/Pango.Application/Common/PasswordConstants.cs
+++ b/src/Core/Pango.Application/Common/PasswordConstants.cs
@@ -4,6 +4,7 @@ public class PasswordConstants
 {
     public const int MinLength = 8;
     public const int MaxLength = 64;
+    public const int SafeLength = 16;
     public const string Uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     public const string Lowercase = "abcdefghijklmnopqrstuvwxyz";
     public const string Digits = "0123456789";

--- a/src/Core/Pango.Application/Common/PasswordGenerationOptions.cs
+++ b/src/Core/Pango.Application/Common/PasswordGenerationOptions.cs
@@ -1,10 +1,10 @@
-﻿namespace Pango.Application.Common
-{
-    public sealed record PasswordGenerationOptions(
-        int Length,
-        bool UseUppercase,
-        bool UseLowercase,
-        bool UseDigits,
-        bool UseSpecial,
-        bool ExcludeAmbiguous);
-}
+﻿namespace Pango.Application.Common;
+
+public sealed record PasswordGenerationOptions(
+    int Length,
+    bool UseUppercase,
+    bool UseLowercase,
+    bool UseDigits,
+    bool UseSpecial,
+    bool ExcludeAmbiguous);
+

--- a/src/Core/Pango.Application/Common/PasswordGenerationOptions.cs
+++ b/src/Core/Pango.Application/Common/PasswordGenerationOptions.cs
@@ -1,0 +1,10 @@
+﻿namespace Pango.Application.Common
+{
+    public sealed record PasswordGenerationOptions(
+        int Length,
+        bool UseUppercase,
+        bool UseLowercase,
+        bool UseDigits,
+        bool UseSpecial,
+        bool ExcludeAmbiguous);
+}

--- a/src/Core/Pango.Application/UseCases/Password/Commands/GeneratePassword/GeneratePasswordCommand.cs
+++ b/src/Core/Pango.Application/UseCases/Password/Commands/GeneratePassword/GeneratePasswordCommand.cs
@@ -1,24 +1,23 @@
 ﻿using ErrorOr;
 using MediatR;
 
-namespace Pango.Application.UseCases.Password.Commands.GeneratePassword
+namespace Pango.Application.UseCases.Password.Commands.GeneratePassword;
+
+public record GeneratePasswordCommand : IRequest<ErrorOr<string>>
 {
-    public record GeneratePasswordCommand : IRequest<ErrorOr<string>>
+    public GeneratePasswordCommand(int length, bool useUppercase, bool useLowercase, bool useDigits, bool useSpecial, bool excludeAmbiguous)
     {
-        public GeneratePasswordCommand(int length, bool useUppercase, bool useLowercase, bool useDigits, bool useSpecial, bool excludeAmbiguous)
-        {
-            Length = length;
-            UseUppercase = useUppercase;
-            UseLowercase = useLowercase;
-            UseDigits = useDigits;
-            UseSpecial = useSpecial;
-            ExcludeAmbiguous = excludeAmbiguous;
-        }
-        public int Length { get; set; }
-        public bool UseUppercase { get; set; }
-        public bool UseLowercase { get; set; }
-        public bool UseDigits { get; set; }
-        public bool UseSpecial { get; set; }
-        public bool ExcludeAmbiguous { get; set; }
+        Length = length;
+        UseUppercase = useUppercase;
+        UseLowercase = useLowercase;
+        UseDigits = useDigits;
+        UseSpecial = useSpecial;
+        ExcludeAmbiguous = excludeAmbiguous;
     }
+    public int Length { get; set; }
+    public bool UseUppercase { get; set; }
+    public bool UseLowercase { get; set; }
+    public bool UseDigits { get; set; }
+    public bool UseSpecial { get; set; }
+    public bool ExcludeAmbiguous { get; set; }
 }

--- a/src/Core/Pango.Application/UseCases/Password/Commands/GeneratePassword/GeneratePasswordCommand.cs
+++ b/src/Core/Pango.Application/UseCases/Password/Commands/GeneratePassword/GeneratePasswordCommand.cs
@@ -1,0 +1,6 @@
+﻿namespace Pango.Application.UseCases.Password.Commands.GeneratePassword
+{
+    public class GeneratePasswordCommand
+    {
+    }
+}

--- a/src/Core/Pango.Application/UseCases/Password/Commands/GeneratePassword/GeneratePasswordCommand.cs
+++ b/src/Core/Pango.Application/UseCases/Password/Commands/GeneratePassword/GeneratePasswordCommand.cs
@@ -1,6 +1,24 @@
-﻿namespace Pango.Application.UseCases.Password.Commands.GeneratePassword
+﻿using ErrorOr;
+using MediatR;
+
+namespace Pango.Application.UseCases.Password.Commands.GeneratePassword
 {
-    public class GeneratePasswordCommand
+    public record GeneratePasswordCommand : IRequest<ErrorOr<string>>
     {
+        public GeneratePasswordCommand(int length, bool useUppercase, bool useLowercase, bool useDigits, bool useSpecial, bool excludeAmbitious)
+        {
+            Length = length;
+            UseUppercase = useUppercase;
+            UseLowercase = useLowercase;
+            UseDigits = useDigits;
+            UseSpecial = useSpecial;
+            ExcludeAmbitious = excludeAmbitious;
+        }
+        public int Length { get; set; }
+        public bool UseUppercase { get; set; }
+        public bool UseLowercase { get; set; }
+        public bool UseDigits { get; set; }
+        public bool UseSpecial { get; set; }
+        public bool ExcludeAmbitious { get; set; }
     }
 }

--- a/src/Core/Pango.Application/UseCases/Password/Commands/GeneratePassword/GeneratePasswordCommand.cs
+++ b/src/Core/Pango.Application/UseCases/Password/Commands/GeneratePassword/GeneratePasswordCommand.cs
@@ -5,20 +5,20 @@ namespace Pango.Application.UseCases.Password.Commands.GeneratePassword
 {
     public record GeneratePasswordCommand : IRequest<ErrorOr<string>>
     {
-        public GeneratePasswordCommand(int length, bool useUppercase, bool useLowercase, bool useDigits, bool useSpecial, bool excludeAmbitious)
+        public GeneratePasswordCommand(int length, bool useUppercase, bool useLowercase, bool useDigits, bool useSpecial, bool excludeAmbiguous)
         {
             Length = length;
             UseUppercase = useUppercase;
             UseLowercase = useLowercase;
             UseDigits = useDigits;
             UseSpecial = useSpecial;
-            ExcludeAmbitious = excludeAmbitious;
+            ExcludeAmbiguous = excludeAmbiguous;
         }
         public int Length { get; set; }
         public bool UseUppercase { get; set; }
         public bool UseLowercase { get; set; }
         public bool UseDigits { get; set; }
         public bool UseSpecial { get; set; }
-        public bool ExcludeAmbitious { get; set; }
+        public bool ExcludeAmbiguous { get; set; }
     }
 }

--- a/src/Core/Pango.Application/UseCases/Password/Commands/GeneratePassword/GeneratePasswordCommandHandler.cs
+++ b/src/Core/Pango.Application/UseCases/Password/Commands/GeneratePassword/GeneratePasswordCommandHandler.cs
@@ -1,6 +1,61 @@
-﻿namespace Pango.Application.UseCases.Password.Commands.GeneratePassword
+﻿using ErrorOr;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Pango.Application.Common;
+using Pango.Application.Common.Interfaces.Persistence;
+
+namespace Pango.Application.UseCases.Password.Commands.GeneratePassword
 {
-    public class GeneratePasswordCommandHandler
+    public class GeneratePasswordCommandHandler : IRequestHandler<GeneratePasswordCommand, ErrorOr<string>>
     {
+        private readonly IPasswordGenerator _passwordGenerator;
+        private readonly ILogger<GeneratePasswordCommandHandler> _logger;
+        public GeneratePasswordCommandHandler(IPasswordGenerator passwordGenerator, ILogger<GeneratePasswordCommandHandler> logger)
+        {
+            _passwordGenerator = passwordGenerator;
+            _logger = logger;
+        }
+        public async Task<ErrorOr<string>> Handle(GeneratePasswordCommand request, CancellationToken cancellationToken)
+        {
+            try
+            {
+                if (request.Length < PasswordConstants.MinLength || request.Length > PasswordConstants.MaxLength)
+                {
+                    return Error.Failure(
+                        ApplicationErrors.Password.GenerationInvalidLength,
+                        $"Password length must be between {PasswordConstants.MinLength} and {PasswordConstants.MaxLength} characters.");
+                }
+
+                if (!request.UseUppercase && !request.UseLowercase && !request.UseDigits && !request.UseSpecial)
+                {
+                    return Error.Failure(
+                        ApplicationErrors.Password.GenerationInvalidCharsets,
+                        "At least one character set must be selected.");
+                }
+                var options = new PasswordGenerationOptions(
+                    request.Length,
+                    request.UseUppercase,
+                    request.UseLowercase,
+                    request.UseDigits,
+                    request.UseSpecial,
+                    request.ExcludeAmbitious
+                );
+
+                var password = await _passwordGenerator.GeneratePassword(options);
+                return password;
+            }
+            catch (Exception ex)
+            {
+                //// to change
+                _logger.LogError(ex,
+                     "Password with length {PasswordLength} cannot be created: {Message}",
+                     request.Length,
+                     ex.Message);
+
+                return Error.Failure(
+                    ApplicationErrors.Password.CreationFailed,
+                    $"Password with length {request.Length} cannot be created: {ex.Message}");
+            }
+        }
     }
 }

--- a/src/Core/Pango.Application/UseCases/Password/Commands/GeneratePassword/GeneratePasswordCommandHandler.cs
+++ b/src/Core/Pango.Application/UseCases/Password/Commands/GeneratePassword/GeneratePasswordCommandHandler.cs
@@ -41,7 +41,7 @@ namespace Pango.Application.UseCases.Password.Commands.GeneratePassword
                     request.ExcludeAmbiguous
                 );
 
-                var password = await _passwordGenerator.GeneratePassword(options);
+                var password = await _passwordGenerator.GeneratePasswordAsync(options);
                 return password;
             }
             catch (Exception ex)

--- a/src/Core/Pango.Application/UseCases/Password/Commands/GeneratePassword/GeneratePasswordCommandHandler.cs
+++ b/src/Core/Pango.Application/UseCases/Password/Commands/GeneratePassword/GeneratePasswordCommandHandler.cs
@@ -1,0 +1,6 @@
+﻿namespace Pango.Application.UseCases.Password.Commands.GeneratePassword
+{
+    public class GeneratePasswordCommandHandler
+    {
+    }
+}

--- a/src/Core/Pango.Application/UseCases/Password/Commands/GeneratePassword/GeneratePasswordCommandHandler.cs
+++ b/src/Core/Pango.Application/UseCases/Password/Commands/GeneratePassword/GeneratePasswordCommandHandler.cs
@@ -38,7 +38,7 @@ namespace Pango.Application.UseCases.Password.Commands.GeneratePassword
                     request.UseLowercase,
                     request.UseDigits,
                     request.UseSpecial,
-                    request.ExcludeAmbitious
+                    request.ExcludeAmbiguous
                 );
 
                 var password = await _passwordGenerator.GeneratePassword(options);

--- a/src/Core/Pango.Application/UseCases/Password/Commands/GeneratePassword/GeneratePasswordCommandHandler.cs
+++ b/src/Core/Pango.Application/UseCases/Password/Commands/GeneratePassword/GeneratePasswordCommandHandler.cs
@@ -4,58 +4,64 @@ using Microsoft.Extensions.Logging;
 using Pango.Application.Common;
 using Pango.Application.Common.Interfaces.Persistence;
 
-namespace Pango.Application.UseCases.Password.Commands.GeneratePassword
+namespace Pango.Application.UseCases.Password.Commands.GeneratePassword;
+
+public class GeneratePasswordCommandHandler : IRequestHandler<GeneratePasswordCommand, ErrorOr<string>>
 {
-    public class GeneratePasswordCommandHandler : IRequestHandler<GeneratePasswordCommand, ErrorOr<string>>
+    private readonly IPasswordGenerator _passwordGenerator;
+    private readonly ILogger<GeneratePasswordCommandHandler> _logger;
+    public GeneratePasswordCommandHandler(IPasswordGenerator passwordGenerator, ILogger<GeneratePasswordCommandHandler> logger)
     {
-        private readonly IPasswordGenerator _passwordGenerator;
-        private readonly ILogger<GeneratePasswordCommandHandler> _logger;
-        public GeneratePasswordCommandHandler(IPasswordGenerator passwordGenerator, ILogger<GeneratePasswordCommandHandler> logger)
+        _passwordGenerator = passwordGenerator;
+        _logger = logger;
+    }
+    public async Task<ErrorOr<string>> Handle(GeneratePasswordCommand request, CancellationToken cancellationToken)
+    {
+        try
         {
-            _passwordGenerator = passwordGenerator;
-            _logger = logger;
-        }
-        public async Task<ErrorOr<string>> Handle(GeneratePasswordCommand request, CancellationToken cancellationToken)
-        {
-            try
+            if (request.Length < PasswordConstants.MinLength || request.Length > PasswordConstants.MaxLength)
             {
-                if (request.Length < PasswordConstants.MinLength || request.Length > PasswordConstants.MaxLength)
-                {
-                    return Error.Failure(
-                        ApplicationErrors.Password.GenerationInvalidLength,
-                        $"Password length must be between {PasswordConstants.MinLength} and {PasswordConstants.MaxLength} characters.");
-                }
-
-                if (!request.UseUppercase && !request.UseLowercase && !request.UseDigits && !request.UseSpecial)
-                {
-                    return Error.Failure(
-                        ApplicationErrors.Password.GenerationInvalidCharsets,
-                        "At least one character set must be selected.");
-                }
-                var options = new PasswordGenerationOptions(
-                    request.Length,
-                    request.UseUppercase,
-                    request.UseLowercase,
-                    request.UseDigits,
-                    request.UseSpecial,
-                    request.ExcludeAmbiguous
-                );
-
-                var password = await _passwordGenerator.GeneratePasswordAsync(options);
-                return password;
-            }
-            catch (Exception ex)
-            {
-                //// to change
-                _logger.LogError(ex,
-                     "Password with length {PasswordLength} cannot be created: {Message}",
-                     request.Length,
-                     ex.Message);
-
                 return Error.Failure(
-                    ApplicationErrors.Password.CreationFailed,
-                    $"Password with length {request.Length} cannot be created: {ex.Message}");
+                    ApplicationErrors.Password.GenerationInvalidLength,
+                    $"Password length must be between {PasswordConstants.MinLength} and {PasswordConstants.MaxLength} characters.");
             }
+
+            if (!request.UseUppercase && !request.UseLowercase && !request.UseDigits && !request.UseSpecial)
+            {
+                return Error.Failure(
+                    ApplicationErrors.Password.GenerationInvalidCharsets,
+                    "At least one character set must be selected.");
+            }
+            var options = new PasswordGenerationOptions(
+                request.Length,
+                request.UseUppercase,
+                request.UseLowercase,
+                request.UseDigits,
+                request.UseSpecial,
+                request.ExcludeAmbiguous
+            );
+
+            var password = await _passwordGenerator.GeneratePasswordAsync(options);
+            return password;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+            "Password generation failed. Length: {Length}, Options: {@GenerationOptions}",
+            request.Length,
+            new
+            {
+                request.UseUppercase,
+                request.UseLowercase,
+                request.UseDigits,
+                request.UseSpecial,
+                request.ExcludeAmbiguous
+            });
+
+            return Error.Failure(
+                ApplicationErrors.Password.CreationFailed,
+                "Unable to generate password.");
         }
     }
 }
+

--- a/src/Infrastructure/Pango.Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/Pango.Infrastructure/DependencyInjection.cs
@@ -12,6 +12,7 @@ public static class DependencyInjection
     {
         services.AddScoped<IUserRepository, UserRepository>();
         services.AddScoped<IContentEncoder, ContentEncoder>();
+        services.AddSingleton<IPasswordGenerator, PasswordGenerator>();
         services.AddFileStorage();
 
         return services;

--- a/src/Infrastructure/Pango.Infrastructure/Services/PasswordGenerator.cs
+++ b/src/Infrastructure/Pango.Infrastructure/Services/PasswordGenerator.cs
@@ -1,70 +1,77 @@
 ﻿using Pango.Application.Common;
 using Pango.Application.Common.Interfaces.Persistence;
-using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 
-namespace Pango.Infrastructure.Services
+namespace Pango.Infrastructure.Services;
+
+public class PasswordGenerator : IPasswordGenerator
 {
-    public class PasswordGenerator : IPasswordGenerator
+    public ValueTask<string> GeneratePasswordAsync(PasswordGenerationOptions options)
     {
-        public Task<string> GeneratePassword(PasswordGenerationOptions options)
+        if (options is null)
+            throw new ArgumentNullException(nameof(options));
+
+        if (options.Length <= 0)
+            throw new ArgumentOutOfRangeException(nameof(options.Length));
+
+        // collect active sets of symbols
+        var charSets = new List<string>();
+        if (options.UseUppercase) charSets.Add(PasswordConstants.Uppercase);
+        if (options.UseLowercase) charSets.Add(PasswordConstants.Lowercase);
+        if (options.UseDigits) charSets.Add(PasswordConstants.Digits);
+        if (options.UseSpecial) charSets.Add(PasswordConstants.Special);
+
+        if (charSets.Count == 0)
+            throw new InvalidOperationException("No characters available for password generation.");
+
+        if (options.ExcludeAmbiguous) 
         {
-            // collect active sets of symbols
-            var charSets = new List<string>();
-            if (options.UseUppercase) charSets.Add(PasswordConstants.Uppercase);
-            if (options.UseLowercase) charSets.Add(PasswordConstants.Lowercase);
-            if (options.UseDigits) charSets.Add(PasswordConstants.Digits);
-            if (options.UseSpecial) charSets.Add(PasswordConstants.Special);
-
-            if (options.ExcludeAmbiguous) 
-            {
-                charSets = charSets
-                    .Select(set => new string(set.Except(PasswordConstants.Ambiguous).ToArray()))
-                    .Where(set => set.Length > 0)
-                    .ToList();
-            }
-
-            var allChars = string.Concat(charSets);
-            var passwordChars = new List<char>(options.Length);
-
-            // ensure existence char from each set
-            using var rng = RandomNumberGenerator.Create();
-            foreach(var set in charSets)
-            {
-                passwordChars.Add(GetRandomChar(set, rng));
-            }
-
-            // get other symbols from general pull
-            for(int i = passwordChars.Count; i < options.Length; i++)
-            {
-                passwordChars.Add(GetRandomChar(allChars, rng));
-            }
-
-            // shuffle
-            Shuffle(passwordChars, rng);
-            var password = new string(passwordChars.ToArray());
-
-            return Task.FromResult(password);
+            charSets = charSets
+                .Select(set => new string(set.Except(PasswordConstants.Ambiguous).ToArray()))
+                .Where(set => set.Length > 0)
+                .ToList();
         }
-        private char GetRandomChar(string set, RandomNumberGenerator rng)
+
+        var allChars = string.Concat(charSets);
+        var passwordChars = new List<char>(options.Length);
+
+        // ensure existence char from each set
+        using var rng = RandomNumberGenerator.Create();
+        foreach(var set in charSets)
+        {
+            passwordChars.Add(GetRandomChar(set, rng));
+        }
+
+        // get other symbols from general pull
+        for(int i = passwordChars.Count; i < options.Length; i++)
+        {
+            passwordChars.Add(GetRandomChar(allChars, rng));
+        }
+
+        // shuffle
+        Shuffle(passwordChars, rng);
+        var password = new string(passwordChars.ToArray());
+
+        return ValueTask.FromResult(password);
+    }
+    private char GetRandomChar(string set, RandomNumberGenerator rng)
+    {
+        var bytes = new byte[4];
+        rng.GetBytes(bytes);
+        var value = BitConverter.ToUInt32(bytes, 0);
+        var index = (int)(value % (uint)set.Length);
+        return set[index];
+    }
+    private void Shuffle(List<char> passwordChars, RandomNumberGenerator rng)
+    {
+        for (int i = passwordChars.Count - 1; i > 0; i--)
         {
             var bytes = new byte[4];
             rng.GetBytes(bytes);
             var value = BitConverter.ToUInt32(bytes, 0);
-            var index = (int)(value % (uint)set.Length);
-            return set[index];
-        }
-        private void Shuffle(List<char> passwordChars, RandomNumberGenerator rng)
-        {
-            for (int i = passwordChars.Count - 1; i > 0; i--)
-            {
-                var bytes = new byte[4];
-                rng.GetBytes(bytes);
-                var value = BitConverter.ToUInt32(bytes, 0);
-                var j = (int)(value % (uint)(i + 1));
+            var j = (int)(value % (uint)(i + 1));
 
-                (passwordChars[i], passwordChars[j]) = (passwordChars[j], passwordChars[i]);
-            }
+            (passwordChars[i], passwordChars[j]) = (passwordChars[j], passwordChars[i]);
         }
     }
 }

--- a/src/Infrastructure/Pango.Infrastructure/Services/PasswordGenerator.cs
+++ b/src/Infrastructure/Pango.Infrastructure/Services/PasswordGenerator.cs
@@ -1,0 +1,70 @@
+﻿using Pango.Application.Common;
+using Pango.Application.Common.Interfaces.Persistence;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+
+namespace Pango.Infrastructure.Services
+{
+    public class PasswordGenerator : IPasswordGenerator
+    {
+        public Task<string> GeneratePassword(PasswordGenerationOptions options)
+        {
+            // collect active sets of symbols
+            var charSets = new List<string>();
+            if (options.UseUppercase) charSets.Add(PasswordConstants.Uppercase);
+            if (options.UseLowercase) charSets.Add(PasswordConstants.Lowercase);
+            if (options.UseDigits) charSets.Add(PasswordConstants.Digits);
+            if (options.UseSpecial) charSets.Add(PasswordConstants.Special);
+
+            if (options.ExcludeAmbiguous) 
+            {
+                charSets = charSets
+                    .Select(set => new string(set.Except(PasswordConstants.Ambiguous).ToArray()))
+                    .Where(set => set.Length > 0)
+                    .ToList();
+            }
+
+            var allChars = string.Concat(charSets);
+            var passwordChars = new List<char>(options.Length);
+
+            // ensure existence char from each set
+            using var rng = RandomNumberGenerator.Create();
+            foreach(var set in charSets)
+            {
+                passwordChars.Add(GetRandomChar(set, rng));
+            }
+
+            // get other symbols from general pull
+            for(int i = passwordChars.Count; i < options.Length; i++)
+            {
+                passwordChars.Add(GetRandomChar(allChars, rng));
+            }
+
+            // shuffle
+            Shuffle(passwordChars, rng);
+            var password = new string(passwordChars.ToArray());
+
+            return Task.FromResult(password);
+        }
+        private char GetRandomChar(string set, RandomNumberGenerator rng)
+        {
+            var bytes = new byte[4];
+            rng.GetBytes(bytes);
+            var value = BitConverter.ToUInt32(bytes, 0);
+            var index = (int)(value % (uint)set.Length);
+            return set[index];
+        }
+        private void Shuffle(List<char> passwordChars, RandomNumberGenerator rng)
+        {
+            for (int i = passwordChars.Count - 1; i > 0; i--)
+            {
+                var bytes = new byte[4];
+                rng.GetBytes(bytes);
+                var value = BitConverter.ToUInt32(bytes, 0);
+                var j = (int)(value % (uint)(i + 1));
+
+                (passwordChars[i], passwordChars[j]) = (passwordChars[j], passwordChars[i]);
+            }
+        }
+    }
+}

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/App.xaml
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/App.xaml
@@ -31,6 +31,7 @@
                     <converters:EmptyStringToRootFolderNameConverter x:Key="EmptyStringToRootFolderNameConverter"/>
                     <converters:BoolReverseConverter x:Key="BoolReverseConverter"/>
                     <converters:StringToVisibilityConverter x:Key="StringToVisibilityConverter"/>
+                    <converters:IntToStringConverter x:Key="IntToStringConverter"/>
                     
                     <!--  Misc resources  -->
                     <Thickness x:Key="DocumentationPageContentPadding">20</Thickness>

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Core/Converters/IntToStringConverter.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Core/Converters/IntToStringConverter.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+using System;
+
+namespace Pango.Desktop.Uwp.Core.Converters;
+
+public sealed class IntToStringConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+        => value?.ToString() ?? string.Empty;
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        var text = value as string;
+
+        if (int.TryParse(text, out var parsed))
+        {
+            return parsed;
+        }
+
+        // letters - don't touch vm
+        return DependencyProperty.UnsetValue;
+    }
+}
+

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Core/Converters/StringToVisibilityConverter.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Core/Converters/StringToVisibilityConverter.cs
@@ -2,22 +2,21 @@
 using Microsoft.UI.Xaml.Data;
 using System;
 
-namespace Pango.Desktop.Uwp.Core.Converters
+namespace Pango.Desktop.Uwp.Core.Converters;
+
+public sealed class StringToVisibilityConverter : IValueConverter
 {
-    public sealed class StringToVisibilityConverter : IValueConverter
+    public object Convert(object value, Type targetType, object parameter, string language)
     {
-        public object Convert(object value, Type targetType, object parameter, string language)
-        {
-            var text = value as string;
+        var text = value as string;
 
-            return string.IsNullOrWhiteSpace(text)
-                ? Visibility.Collapsed
-                : Visibility.Visible;
-        }
+        return string.IsNullOrWhiteSpace(text)
+            ? Visibility.Collapsed
+            : Visibility.Visible;
+    }
 
-        public object ConvertBack(object value, Type targetType, object parameter, string language)
-        {
-            throw new NotSupportedException();
-        }
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        throw new NotSupportedException();
     }
 }

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Dialogs/Validators/ExportDataValidator.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Dialogs/Validators/ExportDataValidator.cs
@@ -1,4 +1,5 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using Pango.Application.Common;
 using System.ComponentModel.DataAnnotations;
 using System.IO;
 using Windows.ApplicationModel.Resources;
@@ -6,26 +7,48 @@ using Windows.ApplicationModel.Resources;
 namespace Pango.Desktop.Uwp.Dialogs.Validators;
 
 /// <summary>
-/// Validator for export data fields, ensuring required inputs and validity.
+/// Provides validation logic for export dialog fields: description, master password,
+/// export file name and target folder.
 /// </summary>
 public partial class ExportDataValidator : ObservableValidator
 {
+    /// <summary>
+    /// Shared resource loader used to obtain localized validation messages.
+    /// </summary>
     private static readonly ResourceLoader _resourceLoader = new();
 
-    private const string FileExtension = ".pngx";
-
+    /// <summary>
+    /// Backing field for <see cref="Description"/>.
+    /// </summary>
     private string _description = string.Empty;
+
+    /// <summary>
+    /// Backing field for <see cref="MasterPassword"/>.
+    /// </summary>
     private string _masterPassword = string.Empty;
+
+    /// <summary>
+    /// Backing field for <see cref="FileName"/>.
+    /// </summary>
     private string _fileName = string.Empty;
+
+    /// <summary>
+    /// Backing field for <see cref="ExportFolderPath"/>.
+    /// </summary>
     private string _exportFolderPath = string.Empty;
 
-    // Constructor initializes and validates all properties
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExportDataValidator"/> class
+    /// and triggers initial validation for all properties.
+    /// </summary>
     public ExportDataValidator()
     {
         ValidateAllProperties();
     }
 
-    // Property for description with custom validation
+    /// <summary>
+    /// Gets or sets the description for the export operation.
+    /// </summary>
     [CustomValidation(typeof(ExportDataValidator), nameof(ValidateDescription))]
     public string Description
     {
@@ -33,7 +56,9 @@ public partial class ExportDataValidator : ObservableValidator
         set => SetProperty(ref _description, value, true);
     }
 
-    // Property for master password with custom validation
+    /// <summary>
+    /// Gets or sets the master password used to protect exported data.
+    /// </summary>
     [CustomValidation(typeof(ExportDataValidator), nameof(ValidatePassword))]
     public string MasterPassword
     {
@@ -41,18 +66,19 @@ public partial class ExportDataValidator : ObservableValidator
         set => SetProperty(ref _masterPassword, value, true);
     }
 
-    // Property for file name with custom validation
+    /// <summary>
+    /// Gets or sets the name of the export file without extension.
+    /// </summary>
     [CustomValidation(typeof(ExportDataValidator), nameof(ValidateFileName))]
     public string FileName
     {
         get => _fileName;
-        set
-        {
-            SetProperty(ref _fileName, value, true);
-        }
+        set => SetProperty(ref _fileName, value, true);
     }
 
-    // Property for export folder path; triggers FileName re-validation on change
+    /// <summary>
+    /// Gets or sets the directory path where the file will be exported.
+    /// </summary>
     [CustomValidation(typeof(ExportDataValidator), nameof(ValidateExportPath))]
     public string ExportFolderPath
     {
@@ -66,23 +92,36 @@ public partial class ExportDataValidator : ObservableValidator
         }
     }
 
-    // Validates description: required and minimum length of 3
+    /// <summary>
+    /// Validates the <see cref="Description"/> value: required and minimum length.
+    /// </summary>
     public static ValidationResult? ValidateDescription(string value)
     {
-        if (string.IsNullOrWhiteSpace(value)) return new ValidationResult(_resourceLoader.GetString("ValidationError_Required"));
-        if (value.Length < 3) return new ValidationResult(_resourceLoader.GetString("ValidationError_MinLength"));
+        if (string.IsNullOrWhiteSpace(value))
+            return new ValidationResult(_resourceLoader.GetString("ValidationError_Required"));
+        if (value.Length < PasswordConstants.MinLength)
+            return new ValidationResult(_resourceLoader.GetString("ValidationError_MinLength"));
+
         return ValidationResult.Success;
     }
 
-    // Validates password: required and minimum length of 3
+    /// <summary>
+    /// Validates the <see cref="MasterPassword"/> value: required and minimum length.
+    /// </summary>
     public static ValidationResult? ValidatePassword(string value)
     {
-        if (string.IsNullOrWhiteSpace(value)) return new ValidationResult(_resourceLoader.GetString("ValidationError_Required"));
-        if (value.Length < 3) return new ValidationResult(_resourceLoader.GetString("ValidationError_MinLength"));
+        if (string.IsNullOrWhiteSpace(value))
+            return new ValidationResult(_resourceLoader.GetString("ValidationError_Required"));
+        if (value.Length < 3)
+            return new ValidationResult(_resourceLoader.GetString("ValidationError_MinLength"));
+
         return ValidationResult.Success;
     }
 
-    // Validates file name: required, no invalid chars, and checks for file existence if path exists
+    /// <summary>
+    /// Validates the <see cref="FileName"/>: required, contains no invalid characters
+    /// and does not already exist in the selected <see cref="ExportFolderPath"/>.
+    /// </summary>
     public static ValidationResult? ValidateFileName(string value, ValidationContext context)
     {
         if (string.IsNullOrWhiteSpace(value))
@@ -97,9 +136,10 @@ public partial class ExportDataValidator : ObservableValidator
         }
 
         var validator = (ExportDataValidator)context.ObjectInstance;
-        if (!string.IsNullOrWhiteSpace(validator.ExportFolderPath) && Directory.Exists(validator.ExportFolderPath))
+        if (!string.IsNullOrWhiteSpace(validator.ExportFolderPath) &&
+            Directory.Exists(validator.ExportFolderPath))
         {
-            string fullPath = Path.Combine(validator.ExportFolderPath, $"{value}{FileExtension}");
+            string fullPath = Path.Combine(validator.ExportFolderPath, $"{value}{AppConstants.ExportFileExtension}");
             if (File.Exists(fullPath))
             {
                 return new ValidationResult(_resourceLoader.GetString("ValidationError_FileExists"));
@@ -109,23 +149,30 @@ public partial class ExportDataValidator : ObservableValidator
         return ValidationResult.Success;
     }
 
-    // Validates export path: required and must be an existing directory
+    /// <summary>
+    /// Validates the <see cref="ExportFolderPath"/>: must be a non-empty existing directory.
+    /// </summary>
     public static ValidationResult? ValidateExportPath(string path)
     {
         if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
         {
             return new ValidationResult(_resourceLoader.GetString("ValidationError_ExportPath"));
         }
+
         return ValidationResult.Success;
     }
 
-    // Manually triggers validation for all properties
+    /// <summary>
+    /// Triggers validation for all decorated properties.
+    /// </summary>
     public void Validate()
     {
         ValidateAllProperties();
     }
 
-    // Resets properties to empty and re-validates
+    /// <summary>
+    /// Resets user-entered values and revalidates all properties.
+    /// </summary>
     public void Reset()
     {
         Description = string.Empty;

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Dialogs/ViewModels/ExportDialogViewModel.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Dialogs/ViewModels/ExportDialogViewModel.cs
@@ -29,7 +29,6 @@ public partial class ExportDialogViewModel : ViewModelBase, IDialogViewModel
 
     private string _exportFolderPath = string.Empty;
     private string _exportingItemsInfo = string.Empty;
-    private const string FileExtension = ".pngx";
     private ExportDataValidator _validator;
 
     #endregion
@@ -129,7 +128,7 @@ public partial class ExportDialogViewModel : ViewModelBase, IDialogViewModel
         else
         {
             var sourcePath = result.Value.Path;
-            string fullDestinationPath = Path.Combine(Validator.ExportFolderPath, $"{Validator.FileName}{FileExtension}");
+            string fullDestinationPath = Path.Combine(Validator.ExportFolderPath, $"{Validator.FileName}{AppConstants.ExportFileExtension}");
 
             try
             {
@@ -151,7 +150,12 @@ public partial class ExportDialogViewModel : ViewModelBase, IDialogViewModel
             }
             catch (Exception ex)
             {
-                Logger.LogError(ex, "Failed to copy exported file to destination folder");
+                Logger.LogError(
+                                ex,
+                                "Failed to copy exported file to destination folder. FileName={FileName}, ExportFolder={ExportFolder}, DestinationPath={DestinationPath}",
+                                Validator.FileName,
+                                Validator.ExportFolderPath,
+                                fullDestinationPath);
                 WeakReferenceMessenger.Default.Send(new InAppNotificationMessage($"Failed to save file to selected folder: {ex.Message}", Core.Enums.AppNotificationType.Error));
                 WeakReferenceMessenger.Default.Send<ExportCompletedMessage>(new ExportCompletedMessage(result.Value));
             }
@@ -188,7 +192,7 @@ public partial class ExportDialogViewModel : ViewModelBase, IDialogViewModel
         try
         {
             string documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-            string defaultExportPath = Path.Combine(documentsPath, "PangoExports");
+            string defaultExportPath = Path.Combine(documentsPath, AppConstants.DefaultExportFolderName);
 
             if (!Directory.Exists(defaultExportPath))
             {

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Models/Parameters/EditPasswordParameters.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Models/Parameters/EditPasswordParameters.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Pango.Desktop.Uwp.Models.Parameters;
 
-public class EditPasswordParameters(bool isNew, string? catalog, Guid? selectedPasswordId, List<string>? availableCatalogs) : INavigationParameter
+public class EditPasswordParameters(bool isNew, string? catalog, Guid? selectedPasswordId, List<string>? availableCatalogs, string? generatedPassword = null) : INavigationParameter
 {
     public bool IsNew { get; } = isNew;
 
@@ -12,4 +12,5 @@ public class EditPasswordParameters(bool isNew, string? catalog, Guid? selectedP
     public Guid? SelectedPasswordId { get; } = selectedPasswordId;
 
     public List<string>? AvailableCatalogs { get; } = availableCatalogs;
+    public string? GeneratedPassword { get; } = generatedPassword;
 }

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Mvvm/Messages/CreatePasswordFromGeneratorMessage.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Mvvm/Messages/CreatePasswordFromGeneratorMessage.cs
@@ -1,11 +1,10 @@
 ﻿using CommunityToolkit.Mvvm.Messaging.Messages;
 
-namespace Pango.Desktop.Uwp.Mvvm.Messages
+namespace Pango.Desktop.Uwp.Mvvm.Messages;
+
+public class CreatePasswordFromGeneratorMessage : ValueChangedMessage<string>
 {
-    public class CreatePasswordFromGeneratorMessage : ValueChangedMessage<string>
+    public CreatePasswordFromGeneratorMessage(string value) : base(value)
     {
-        public CreatePasswordFromGeneratorMessage(string value) : base(value)
-        {
-        }
     }
 }

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Mvvm/Messages/CreatePasswordFromGeneratorMessage.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Mvvm/Messages/CreatePasswordFromGeneratorMessage.cs
@@ -1,0 +1,11 @@
+﻿using CommunityToolkit.Mvvm.Messaging.Messages;
+
+namespace Pango.Desktop.Uwp.Mvvm.Messages
+{
+    public class CreatePasswordFromGeneratorMessage : ValueChangedMessage<string>
+    {
+        public CreatePasswordFromGeneratorMessage(string value) : base(value)
+        {
+        }
+    }
+}

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Strings/be-BY/Resources.resw
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Strings/be-BY/Resources.resw
@@ -595,4 +595,40 @@
   <data name="GeneratePasswordTooltip" xml:space="preserve">
     <value>Стварыць надзейны пароль</value>
   </data>
+  <data name="PasswordLengthTooltip" xml:space="preserve">
+    <value>Даўжыня пароля (8-64 сімвала)</value>
+  </data>
+  <data name="PasswordLengthUnits" xml:space="preserve">
+    <value>сімвалы</value>
+  </data>
+  <data name="UseUppercaseTooltip" xml:space="preserve">
+    <value>Дадайце загалоўныя літары (A-Z), каб павысіць надзейнасць пароля</value>
+  </data>
+  <data name="UseDigitsTooltip" xml:space="preserve">
+    <value>Дадайце лічбы (0-9), каб павысіць надзейнасць пароля</value>
+  </data>
+  <data name="UseLowercaseTooltip" xml:space="preserve">
+    <value>Дадайце малыя літары (A-z), каб павысіць надзейнасць пароля</value>
+  </data>
+  <data name="ExcludeAmbiguousTooltip" xml:space="preserve">
+    <value>Выключыць сімвалы, якія могуць выглядаць падобнымі (Il10oOsS5)</value>
+  </data>
+  <data name="UseSpecialTooltip" xml:space="preserve">
+    <value>Дадайце спецыяльныя сімвалы, каб абцяжарыць падбор пароля</value>
+  </data>
+  <data name="PasswordLength_OutOfRange" xml:space="preserve">
+    <value>Даўжыня пароля павінна складаць ад 8 да 64 сімвалаў</value>
+  </data>
+  <data name="PasswordLength_Invalid" xml:space="preserve">
+    <value>Недапушчальнае значэнне даўжыні пароля</value>
+  </data>
+  <data name="RegeneratePassword" xml:space="preserve">
+    <value>Стварыць новы пароль</value>
+  </data>
+  <data name="OtherPasswords" xml:space="preserve">
+    <value>Іншыя прапанаваныя паролі</value>
+  </data>
+  <data name="PasswordGeneratedSuccessfully" xml:space="preserve">
+    <value>Пароль паспяхова згенераваны</value>
+  </data>
 </root>

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Strings/be-BY/Resources.resw
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Strings/be-BY/Resources.resw
@@ -595,37 +595,4 @@
   <data name="GeneratePasswordTooltip" xml:space="preserve">
     <value>Стварыць надзейны пароль</value>
   </data>
-  <data name="PasswordLengthTooltip" xml:space="preserve">
-    <value>Даўжыня пароля (8-64 сімвала)</value>
-  </data>
-  <data name="PasswordLengthUnits" xml:space="preserve">
-    <value>сімвалы</value>
-  </data>
-  <data name="UseUppercaseTooltip" xml:space="preserve">
-    <value>Дадайце загалоўныя літары (A-Z), каб павысіць надзейнасць пароля</value>
-  </data>
-  <data name="UseDigitsTooltip" xml:space="preserve">
-    <value>Дадайце лічбы (0-9), каб павысіць надзейнасць пароля</value>
-  </data>
-  <data name="UseLowercaseTooltip" xml:space="preserve">
-    <value>Дадайце малыя літары (A-z), каб павысіць надзейнасць пароля</value>
-  </data>
-  <data name="ExcludeAmbiguousTooltip" xml:space="preserve">
-    <value>Выключыць сімвалы, якія могуць выглядаць падобнымі (Il10oOsS5)</value>
-  </data>
-  <data name="UseSpecialTooltip" xml:space="preserve">
-    <value>Дадайце спецыяльныя сімвалы, каб абцяжарыць падбор пароля</value>
-  </data>
-  <data name="PasswordLength_OutOfRange" xml:space="preserve">
-    <value>Даўжыня пароля павінна складаць ад 8 да 64 сімвалаў</value>
-  </data>
-  <data name="PasswordLength_Invalid" xml:space="preserve">
-    <value>Недапушчальнае значэнне даўжыні пароля</value>
-  </data>
-  <data name="RegeneratePassword" xml:space="preserve">
-    <value>Стварыць новы пароль</value>
-  </data>
-  <data name="OtherPasswords" xml:space="preserve">
-    <value>Іншыя прапанаваныя паролі</value>
-  </data>
 </root>

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Strings/be-BY/Resources.resw
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Strings/be-BY/Resources.resw
@@ -631,4 +631,7 @@
   <data name="PasswordGeneratedSuccessfully" xml:space="preserve">
     <value>Пароль паспяхова згенераваны</value>
   </data>
+  <data name="SaveAs" xml:space="preserve">
+    <value>Захаваць як</value>
+  </data>
 </root>

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Strings/en-US/Resources.resw
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Strings/en-US/Resources.resw
@@ -597,4 +597,40 @@
   <data name="GeneratePasswordTooltip" xml:space="preserve">
     <value>Create a strong password</value>
   </data>
+  <data name="PasswordLengthTooltip" xml:space="preserve">
+    <value>Password length (8–64 characters)</value>
+  </data>
+  <data name="PasswordLengthUnits" xml:space="preserve">
+    <value>chars</value>
+  </data>
+  <data name="UseUppercaseTooltip" xml:space="preserve">
+    <value>Add uppercase letters (A–Z) to increase password strength</value>
+  </data>
+  <data name="UseDigitsTooltip" xml:space="preserve">
+    <value>Add digits (0–9) to increase password strength</value>
+  </data>
+  <data name="UseLowercaseTooltip" xml:space="preserve">
+    <value>Add lowercase letters (a–z) to increase password strength</value>
+  </data>
+  <data name="ExcludeAmbiguousTooltip" xml:space="preserve">
+    <value>Exclude characters that can look similar (Il10oOsS5)</value>
+  </data>
+  <data name="UseSpecialTooltip" xml:space="preserve">
+    <value>Add special characters to make the password harder to guess</value>
+  </data>
+  <data name="PasswordLength_OutOfRange" xml:space="preserve">
+    <value>Password length must be between 8 and 64 characters</value>
+  </data>
+  <data name="PasswordLength_Invalid" xml:space="preserve">
+    <value>Invalid password length value</value>
+  </data>
+  <data name="RegeneratePassword" xml:space="preserve">
+    <value>Generate new password</value>
+  </data>
+  <data name="OtherPasswords" xml:space="preserve">
+    <value>Other suggested passwords</value>
+  </data>
+  <data name="PasswordGeneratedSuccessfully" xml:space="preserve">
+    <value>Password generated successfully</value>
+  </data>
 </root>

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Strings/en-US/Resources.resw
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Strings/en-US/Resources.resw
@@ -597,37 +597,4 @@
   <data name="GeneratePasswordTooltip" xml:space="preserve">
     <value>Create a strong password</value>
   </data>
-  <data name="PasswordLengthTooltip" xml:space="preserve">
-    <value>Password length (8–64 characters)</value>
-  </data>
-  <data name="PasswordLengthUnits" xml:space="preserve">
-    <value>chars</value>
-  </data>
-  <data name="UseUppercaseTooltip" xml:space="preserve">
-    <value>Add uppercase letters (A–Z) to increase password strength</value>
-  </data>
-  <data name="UseDigitsTooltip" xml:space="preserve">
-    <value>Add digits (0–9) to increase password strength</value>
-  </data>
-  <data name="UseLowercaseTooltip" xml:space="preserve">
-    <value>Add lowercase letters (a–z) to increase password strength</value>
-  </data>
-  <data name="ExcludeAmbiguousTooltip" xml:space="preserve">
-    <value>Exclude characters that can look similar (Il10oOsS5)</value>
-  </data>
-  <data name="UseSpecialTooltip" xml:space="preserve">
-    <value>Add special characters to make the password harder to guess</value>
-  </data>
-  <data name="PasswordLength_OutOfRange" xml:space="preserve">
-    <value>Password length must be between 8 and 64 characters</value>
-  </data>
-  <data name="PasswordLength_Invalid" xml:space="preserve">
-    <value>Invalid password length value</value>
-  </data>
-  <data name="RegeneratePassword" xml:space="preserve">
-    <value>Generate new password</value>
-  </data>
-  <data name="OtherPasswords" xml:space="preserve">
-    <value>Other suggested passwords</value>
-  </data>
 </root>

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Strings/en-US/Resources.resw
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Strings/en-US/Resources.resw
@@ -633,4 +633,7 @@
   <data name="PasswordGeneratedSuccessfully" xml:space="preserve">
     <value>Password generated successfully</value>
   </data>
+  <data name="SaveAs" xml:space="preserve">
+    <value>Save as</value>
+  </data>
 </root>

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/EditPasswordViewModel.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/EditPasswordViewModel.cs
@@ -138,6 +138,11 @@ public class EditPasswordViewModel : ViewModelBase
             else
             {
                 PasswordValidator!.SelectedCatalog = parameters.Catalog;
+
+                if (!string.IsNullOrEmpty(parameters.GeneratedPassword))
+                {
+                    PasswordValidator.Password = parameters.GeneratedPassword;
+                }
             }
         }
     }

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/GeneratePasswordViewModel.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/GeneratePasswordViewModel.cs
@@ -4,6 +4,7 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI;
 using Microsoft.UI.Xaml.Media;
+using Pango.Application.Common;
 using Pango.Application.UseCases.Password.Commands.GeneratePassword;
 using Pango.Desktop.Uwp.Core.Enums;
 using Pango.Desktop.Uwp.Models.Parameters;
@@ -13,386 +14,384 @@ using System.Linq;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.DataTransfer;
 
-namespace Pango.Desktop.Uwp.ViewModels
+namespace Pango.Desktop.Uwp.ViewModels;
+
+public sealed class GeneratePasswordViewModel : ViewModelBase
 {
-    public sealed class GeneratePasswordViewModel : ViewModelBase
+    #region Fields
+    private readonly ISender _sender;
+    private string _generatedPassword = string.Empty;
+    private int _length = 16;
+    private string _lengthText = "16";
+    private string _lengthError;
+    private string _charsetsError;
+    private bool _useUppercase = true;
+    private bool _useLowercase = true;
+    private bool _useDigits = true;
+    private bool _useSpecial = false;
+    private bool _excludeAmbiguous = false;
+    private PasswordStrength _strength;
+    #endregion
+
+    #region Properties
+    public string GeneratedPassword
     {
-        #region Fields
-        private readonly ISender _sender;
-        private string _generatedPassword = string.Empty;
-        private int _length = 16;
-        private string _lengthText = "16";
-        private string _lengthError;
-        private string _charsetsError;
-        private bool _useUppercase = true;
-        private bool _useLowercase = true;
-        private bool _useDigits = true;
-        private bool _useSpecial = false;
-        private bool _excludeAmbiguous = false;
-        private PasswordStrength _strength;
-        #endregion
-
-        #region Properties
-        public string GeneratedPassword
+        get => _generatedPassword;
+        private set
         {
-            get => _generatedPassword;
-            private set
-            {
-                if (_generatedPassword == value)
-                    return;
-
-                _generatedPassword = value;
-                OnPropertyChanged(nameof(GeneratedPassword));
-                UpdateStrength();
-                CopyPasswordCommand.NotifyCanExecuteChanged();
-                SaveAsCommand.NotifyCanExecuteChanged();
-            }
-        }
-
-        public int Length
-        {
-            get => _length;
-            set
-            {
-                if (_length == value)
-                    return;
-
-                _length = value;
-                OnPropertyChanged(nameof(Length));
-            }
-        }
-        public string LengthText
-        {
-            get => _lengthText;
-            set
-            {
-                if (_lengthText == value)
-                    return;
-
-                _lengthText = value;
-                OnPropertyChanged(nameof(LengthText));
-
-                ValidateLengthInput(value);
-            }
-        }
-        public string LengthError
-        {
-            get => _lengthError;
-            set
-            {
-                if (_lengthError == value)
-                    return;
-
-                _lengthError = value;
-                OnPropertyChanged(nameof(LengthError));
-            }
-        }
-        public string CharsetsError
-        {
-            get => _charsetsError;
-            set
-            {
-                if (_charsetsError == value)
-                    return;
-
-                _charsetsError = value;
-                OnPropertyChanged(nameof(CharsetsError));
-            }
-        }
-
-
-        public bool UseUppercase
-        {
-            get => _useUppercase;
-            set
-            {
-                if (_useUppercase == value)
-                    return;
-
-                _useUppercase = value;
-                OnPropertyChanged(nameof(UseUppercase));
-            }
-        }
-
-        public bool UseLowercase
-        {
-            get => _useLowercase;
-            set
-            {
-                if (_useLowercase == value)
-                    return;
-
-                _useLowercase = value;
-                OnPropertyChanged(nameof(UseLowercase));
-            }
-        }
-
-        public bool UseDigits
-        {
-            get => _useDigits;
-            set
-            {
-                if (_useDigits == value)
-                    return;
-
-                _useDigits = value;
-                OnPropertyChanged(nameof(UseDigits));
-            }
-        }
-
-        public bool UseSpecial
-        {
-            get => _useSpecial;
-            set
-            {
-                if (_useSpecial == value)
-                    return;
-
-                _useSpecial = value;
-                OnPropertyChanged(nameof(UseSpecial));
-            }
-        }
-
-        public bool ExcludeAmbiguous
-        {
-            get => _excludeAmbiguous;
-            set
-            {
-                if (_excludeAmbiguous == value)
-                    return;
-
-                _excludeAmbiguous = value;
-                OnPropertyChanged(nameof(ExcludeAmbiguous));
-            }
-        }
-
-        public PasswordStrength Strength
-        {
-            get => _strength;
-            private set
-            {
-                if (_strength == value)
-                    return;
-
-                _strength = value;
-                OnPropertyChanged(nameof(Strength));
-                OnPropertyChanged(nameof(StrengthLabel));
-                OnPropertyChanged(nameof(StrengthBrush));
-            }
-        }
-
-        public string StrengthLabel =>
-            Strength switch
-            {
-                PasswordStrength.Weak => ViewResourceLoader.GetString("PasswordStrength_Weak"),
-                PasswordStrength.Medium => ViewResourceLoader.GetString("PasswordStrength_Medium"),
-                PasswordStrength.Strong => ViewResourceLoader.GetString("PasswordStrength_Strong"),
-                _ => string.Empty
-            };
-
-        public SolidColorBrush StrengthBrush =>
-            Strength switch
-            {
-                PasswordStrength.Weak => new SolidColorBrush(Colors.Red),
-                PasswordStrength.Medium => new SolidColorBrush(Colors.Orange),
-                PasswordStrength.Strong => new SolidColorBrush(Colors.Green),
-                _ => new SolidColorBrush(Colors.Gray)
-            };
-
-        #endregion
-
-        #region Commands
-
-        public IAsyncRelayCommand GenerateCommand { get; }
-        public IAsyncRelayCommand RegeneratePasswordCommand { get; }
-        public RelayCommand CopyPasswordCommand { get; }
-        public RelayCommand ApplyCommand { get; }
-        public RelayCommand CancelCommand { get; }
-        public RelayCommand SaveAsCommand { get; }
-
-        #endregion
-
-        public GeneratePasswordViewModel(ISender sender, ILogger<GeneratePasswordViewModel> logger)
-            : base(logger)
-        {
-            _sender = sender;
-
-            GenerateCommand = new AsyncRelayCommand(GenerateAsync);
-            RegeneratePasswordCommand = new AsyncRelayCommand(GenerateAsync);
-            CopyPasswordCommand = new RelayCommand(CopyPassword, CanCopyPassword);
-            ApplyCommand = new RelayCommand(Apply);
-            CancelCommand = new RelayCommand(Cancel);
-            SaveAsCommand = new RelayCommand(SaveAs, CanSaveAs);
-        }
-
-        #region Overrides
-        public override async Task OnNavigatedToAsync(object? parameter)
-        {
-            await base.OnNavigatedToAsync(parameter);
-
-            Clear();
-        }
-        #endregion
-
-        private async Task GenerateAsync()
-        {
-            if (!ValidateLengthInput(LengthText))
-                return;
-            if (!ValidateCharsets())
-                return;
-            var command = new GeneratePasswordCommand(
-                Length,
-                UseUppercase,
-                UseLowercase,
-                UseDigits,
-                UseSpecial,
-                ExcludeAmbiguous);
-
-            var result = await _sender.Send(command);
-
-            if (result.IsError)
-            {
-                Logger.LogError("Password generation failed: {Errors}", string.Join(", ", result.Errors));
-
-                var message = result.FirstError.Description
-                              ?? ViewResourceLoader.GetString("PasswordGenerationFailed");
-
-                WeakReferenceMessenger.Default.Send(
-                    new InAppNotificationMessage(message, AppNotificationType.Error));
-
-                return;
-            }
-
-            GeneratedPassword = result.Value;
-
-            WeakReferenceMessenger.Default.Send(
-                new InAppNotificationMessage(
-                    ViewResourceLoader.GetString("PasswordGeneratedSuccessfully")));
-        }
-        private bool ValidateLengthInput(string text)
-        {
-            if (!int.TryParse(text, out var parsed))
-            {
-                LengthError = ViewResourceLoader.GetString("PasswordLength_Invalid");
-                return false;
-            }
-
-            if (parsed < 8 || parsed > 64)
-            {
-                LengthError = ViewResourceLoader.GetString("PasswordLength_OutOfRange");
-                return false;
-            }
-
-            LengthError = string.Empty;
-            Length = parsed;
-            return true;
-        }
-        private bool ValidateCharsets()
-        {
-            if (!UseUppercase && !UseLowercase && !UseDigits && !UseSpecial)
-            {
-                CharsetsError = ViewResourceLoader.GetString("PasswordGeneration_Error_NoCharSet");
-                return false;
-            }
-
-            CharsetsError = string.Empty;
-            return true;
-        }       
-        private bool CanCopyPassword() => !string.IsNullOrEmpty(GeneratedPassword);
-        private void CopyPassword()
-        {
-            if (string.IsNullOrEmpty(GeneratedPassword))
+            if (_generatedPassword == value)
                 return;
 
-            var dataPackage = new DataPackage
-            {
-                RequestedOperation = DataPackageOperation.Copy
-            };
-            dataPackage.SetText(GeneratedPassword);
-            Clipboard.SetContent(dataPackage);
-
-            WeakReferenceMessenger.Default.Send(
-                new InAppNotificationMessage(
-                    ViewResourceLoader.GetString("PasswordCopiedToClipboard"),
-                    AppNotificationType.Success));
+            _generatedPassword = value;
+            OnPropertyChanged(nameof(GeneratedPassword));
+            UpdateStrength();
+            CopyPasswordCommand.NotifyCanExecuteChanged();
+            SaveAsCommand.NotifyCanExecuteChanged();
         }
-        private void Apply()
-        {
-            // TODO: Implement Apply functionality
-            Logger.LogInformation(
-                "Apply password clicked with value length {Length}",
-                GeneratedPassword?.Length ?? 0);
-        }
-
-        private void Cancel()
-        {
-            // TODO: Implement Cancel functionality
-            Logger.LogInformation("Cancel password generation clicked.");
-        }
-
-        private bool CanSaveAs() => !string.IsNullOrEmpty(GeneratedPassword);
-        private void SaveAs()
-        {
-            if (string.IsNullOrEmpty(GeneratedPassword))
-                return;
-
-            // navigation on PasswordsIndex
-            WeakReferenceMessenger.Default.Send(
-                new NavigationRequstedMessage(
-                    new NavigationParameters(AppView.PasswordsIndex, AppView.GeneratePassword)));
-
-            // separate message - create new password with generated value
-            WeakReferenceMessenger.Default.Send(new CreatePasswordFromGeneratorMessage(GeneratedPassword));
-        }
-
-        private void Clear()
-        {
-            GeneratedPassword = string.Empty;
-            Length = 16;
-            LengthText = "16";
-            LengthError = string.Empty;
-
-            UseUppercase = true;
-            UseLowercase = true;
-            UseDigits = true;
-            UseSpecial = false;
-            ExcludeAmbiguous = false;
-
-            Strength = PasswordStrength.Weak;
-        }              
-
-        private void UpdateStrength()
-        {
-            var password = GeneratedPassword ?? string.Empty;
-
-            if (password.Length == 0)
-            {
-                Strength = PasswordStrength.Weak;
-                return;
-            }
-
-            int score = 0;
-
-            if (password.Length >= 8) score += 2;
-            if (password.Length >= 12) score += 2;
-            if (password.Length >= 16) score += 2;
-
-            if (ContainsUpper(password)) score += 1;
-            if (ContainsLower(password)) score += 1;
-            if (ContainsDigit(password)) score += 1;
-            if (ContainsSpecial(password)) score += 1;
-
-            if (score <= 3)
-                Strength = PasswordStrength.Weak;
-            else if (score <= 6)
-                Strength = PasswordStrength.Medium;
-            else
-                Strength = PasswordStrength.Strong;
-        }
-        private static bool ContainsUpper(string s) => s.Any(char.IsUpper);
-        private static bool ContainsLower(string s) => s.Any(char.IsLower);
-        private static bool ContainsDigit(string s) => s.Any(char.IsDigit);
-        private static bool ContainsSpecial(string s) => s.Any(c => !char.IsLetterOrDigit(c));
     }
 
+    public int Length
+    {
+        get => _length;
+        set
+        {
+            if (_length == value)
+                return;
+
+            _length = value;
+            OnPropertyChanged(nameof(Length));
+        }
+    }
+    public string LengthText
+    {
+        get => _lengthText;
+        set
+        {
+            if (_lengthText == value)
+                return;
+
+            _lengthText = value;
+            OnPropertyChanged(nameof(LengthText));
+
+            ValidateLengthInput(value);
+        }
+    }
+    public string LengthError
+    {
+        get => _lengthError;
+        set
+        {
+            if (_lengthError == value)
+                return;
+
+            _lengthError = value;
+            OnPropertyChanged(nameof(LengthError));
+        }
+    }
+    public string CharsetsError
+    {
+        get => _charsetsError;
+        set
+        {
+            if (_charsetsError == value)
+                return;
+
+            _charsetsError = value;
+            OnPropertyChanged(nameof(CharsetsError));
+        }
+    }
+
+
+    public bool UseUppercase
+    {
+        get => _useUppercase;
+        set
+        {
+            if (_useUppercase == value)
+                return;
+
+            _useUppercase = value;
+            OnPropertyChanged(nameof(UseUppercase));
+        }
+    }
+
+    public bool UseLowercase
+    {
+        get => _useLowercase;
+        set
+        {
+            if (_useLowercase == value)
+                return;
+
+            _useLowercase = value;
+            OnPropertyChanged(nameof(UseLowercase));
+        }
+    }
+
+    public bool UseDigits
+    {
+        get => _useDigits;
+        set
+        {
+            if (_useDigits == value)
+                return;
+
+            _useDigits = value;
+            OnPropertyChanged(nameof(UseDigits));
+        }
+    }
+
+    public bool UseSpecial
+    {
+        get => _useSpecial;
+        set
+        {
+            if (_useSpecial == value)
+                return;
+
+            _useSpecial = value;
+            OnPropertyChanged(nameof(UseSpecial));
+        }
+    }
+
+    public bool ExcludeAmbiguous
+    {
+        get => _excludeAmbiguous;
+        set
+        {
+            if (_excludeAmbiguous == value)
+                return;
+
+            _excludeAmbiguous = value;
+            OnPropertyChanged(nameof(ExcludeAmbiguous));
+        }
+    }
+
+    public PasswordStrength Strength
+    {
+        get => _strength;
+        private set
+        {
+            if (_strength == value)
+                return;
+
+            _strength = value;
+            OnPropertyChanged(nameof(Strength));
+            OnPropertyChanged(nameof(StrengthLabel));
+            OnPropertyChanged(nameof(StrengthBrush));
+        }
+    }
+
+    public string StrengthLabel =>
+        Strength switch
+        {
+            PasswordStrength.Weak => ViewResourceLoader.GetString("PasswordStrength_Weak"),
+            PasswordStrength.Medium => ViewResourceLoader.GetString("PasswordStrength_Medium"),
+            PasswordStrength.Strong => ViewResourceLoader.GetString("PasswordStrength_Strong"),
+            _ => string.Empty
+        };
+
+    public SolidColorBrush StrengthBrush =>
+        Strength switch
+        {
+            PasswordStrength.Weak => new SolidColorBrush(Colors.Red),
+            PasswordStrength.Medium => new SolidColorBrush(Colors.Orange),
+            PasswordStrength.Strong => new SolidColorBrush(Colors.Green),
+            _ => new SolidColorBrush(Colors.Gray)
+        };
+
+    #endregion
+
+    #region Commands
+
+    public IAsyncRelayCommand GenerateCommand { get; }
+    public IAsyncRelayCommand RegeneratePasswordCommand { get; }
+    public RelayCommand CopyPasswordCommand { get; }
+    public RelayCommand ApplyCommand { get; }
+    public RelayCommand CancelCommand { get; }
+    public RelayCommand SaveAsCommand { get; }
+
+    #endregion
+
+    public GeneratePasswordViewModel(ISender sender, ILogger<GeneratePasswordViewModel> logger)
+        : base(logger)
+    {
+        _sender = sender;
+
+        GenerateCommand = new AsyncRelayCommand(GenerateAsync);
+        RegeneratePasswordCommand = new AsyncRelayCommand(GenerateAsync);
+        CopyPasswordCommand = new RelayCommand(CopyPassword, CanCopyPassword);
+        ApplyCommand = new RelayCommand(Apply);
+        CancelCommand = new RelayCommand(Cancel);
+        SaveAsCommand = new RelayCommand(SaveAs, CanSaveAs);
+    }
+
+    #region Overrides
+    public override async Task OnNavigatedToAsync(object? parameter)
+    {
+        await base.OnNavigatedToAsync(parameter);
+
+        Clear();
+    }
+    #endregion
+
+    private async Task GenerateAsync()
+    {
+        if (!ValidateLengthInput(LengthText))
+            return;
+        if (!ValidateCharsets())
+            return;
+        var command = new GeneratePasswordCommand(
+            Length,
+            UseUppercase,
+            UseLowercase,
+            UseDigits,
+            UseSpecial,
+            ExcludeAmbiguous);
+
+        var result = await _sender.Send(command);
+
+        if (result.IsError)
+        {
+            Logger.LogError("Password generation failed: {Errors}", string.Join(", ", result.Errors));
+
+            var message = result.FirstError.Description
+                          ?? ViewResourceLoader.GetString("PasswordGenerationFailed");
+
+            WeakReferenceMessenger.Default.Send(
+                new InAppNotificationMessage(message, AppNotificationType.Error));
+
+            return;
+        }
+
+        GeneratedPassword = result.Value;
+
+        WeakReferenceMessenger.Default.Send(
+            new InAppNotificationMessage(
+                ViewResourceLoader.GetString("PasswordGeneratedSuccessfully")));
+    }
+    private bool ValidateLengthInput(string text)
+    {
+        if (!int.TryParse(text, out var parsed))
+        {
+            LengthError = ViewResourceLoader.GetString("PasswordLength_Invalid");
+            return false;
+        }
+
+        if (parsed < PasswordConstants.MinLength || parsed > PasswordConstants.MaxLength)
+        {
+            LengthError = ViewResourceLoader.GetString("PasswordLength_OutOfRange");
+            return false;
+        }
+
+        LengthError = string.Empty;
+        Length = parsed;
+        return true;
+    }
+    private bool ValidateCharsets()
+    {
+        if (!UseUppercase && !UseLowercase && !UseDigits && !UseSpecial)
+        {
+            CharsetsError = ViewResourceLoader.GetString("PasswordGeneration_Error_NoCharSet");
+            return false;
+        }
+
+        CharsetsError = string.Empty;
+        return true;
+    }
+    private bool CanCopyPassword() => !string.IsNullOrEmpty(GeneratedPassword);
+    private void CopyPassword()
+    {
+        if (string.IsNullOrEmpty(GeneratedPassword))
+            return;
+
+        var dataPackage = new DataPackage
+        {
+            RequestedOperation = DataPackageOperation.Copy
+        };
+        dataPackage.SetText(GeneratedPassword);
+        Clipboard.SetContent(dataPackage);
+
+        WeakReferenceMessenger.Default.Send(
+            new InAppNotificationMessage(
+                ViewResourceLoader.GetString("PasswordCopiedToClipboard"),
+                AppNotificationType.Success));
+    }
+    private void Apply()
+    {
+        // TODO: Implement Apply functionality
+        Logger.LogInformation(
+            "Apply password clicked with value length {Length}",
+            GeneratedPassword?.Length ?? 0);
+    }
+
+    private void Cancel()
+    {
+        // TODO: Implement Cancel functionality
+        Logger.LogInformation("Cancel password generation clicked.");
+    }
+
+    private bool CanSaveAs() => !string.IsNullOrEmpty(GeneratedPassword);
+    private void SaveAs()
+    {
+        if (string.IsNullOrEmpty(GeneratedPassword))
+            return;
+
+        // navigation on PasswordsIndex
+        WeakReferenceMessenger.Default.Send(
+            new NavigationRequstedMessage(
+                new NavigationParameters(AppView.PasswordsIndex, AppView.GeneratePassword)));
+
+        // separate message - create new password with generated value
+        WeakReferenceMessenger.Default.Send(new CreatePasswordFromGeneratorMessage(GeneratedPassword));
+    }
+
+    private void Clear()
+    {
+        GeneratedPassword = string.Empty;
+        Length = PasswordConstants.MinLength;
+        LengthText = PasswordConstants.MinLength.ToString();
+        LengthError = string.Empty;
+
+        UseUppercase = true;
+        UseLowercase = true;
+        UseDigits = true;
+        UseSpecial = false;
+        ExcludeAmbiguous = false;
+
+        Strength = PasswordStrength.Weak;
+    }
+
+    private void UpdateStrength()
+    {
+        var password = GeneratedPassword ?? string.Empty;
+
+        if (password.Length == 0)
+        {
+            Strength = PasswordStrength.Weak;
+            return;
+        }
+
+        int score = 0;
+
+        if (password.Length >= 8) score += 2;
+        if (password.Length >= 12) score += 2;
+        if (password.Length >= 16) score += 2;
+
+        if (ContainsUpper(password)) score += 1;
+        if (ContainsLower(password)) score += 1;
+        if (ContainsDigit(password)) score += 1;
+        if (ContainsSpecial(password)) score += 1;
+
+        if (score <= 3)
+            Strength = PasswordStrength.Weak;
+        else if (score <= 6)
+            Strength = PasswordStrength.Medium;
+        else
+            Strength = PasswordStrength.Strong;
+    }
+    private static bool ContainsUpper(string s) => s.Any(char.IsUpper);
+    private static bool ContainsLower(string s) => s.Any(char.IsLower);
+    private static bool ContainsDigit(string s) => s.Any(char.IsDigit);
+    private static bool ContainsSpecial(string s) => s.Any(c => !char.IsLetterOrDigit(c));
 }

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/GeneratePasswordViewModel.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/GeneratePasswordViewModel.cs
@@ -4,42 +4,179 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI;
 using Microsoft.UI.Xaml.Media;
-using Microsoft.VisualBasic;
 using Pango.Application.UseCases.Password.Commands.GeneratePassword;
 using Pango.Desktop.Uwp.Core.Enums;
 using Pango.Desktop.Uwp.Mvvm.Models;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Windows.Input;
 using Windows.ApplicationModel.DataTransfer;
 
 namespace Pango.Desktop.Uwp.ViewModels
 {
     public sealed class GeneratePasswordViewModel : ViewModelBase
     {
-        public string GeneratedPassword { get; set; } = string.Empty;
-        public int Length { get; set; } = 16;
+        private readonly ISender _sender;
 
-        public bool UseUppercase { get; set; } = true;
-        public bool UseLowercase { get; set; } = true;
-        public bool UseDigits { get; set; } = true;
-        public bool UseSpecial { get; set; } = false;
-        public bool ExcludeAmbiguous { get; set; } = false;
+        private string _generatedPassword = string.Empty;
+        private int _length = 16;
+        private string _lengthText = "16";
+        private string _lengthError;
+        private string _charsetsError;
+        private bool _useUppercase = true;
+        private bool _useLowercase = true;
+        private bool _useDigits = true;
+        private bool _useSpecial = false;
+        private bool _excludeAmbiguous = false;
+        private PasswordStrength _strength;
+
+        #region Properties
+        public string GeneratedPassword
+        {
+            get => _generatedPassword;
+            private set
+            {
+                if (_generatedPassword == value)
+                    return;
+
+                _generatedPassword = value;
+                OnPropertyChanged(nameof(GeneratedPassword));
+                UpdateStrength();
+                CopyPasswordCommand.NotifyCanExecuteChanged();
+            }
+        }
+
+        public int Length
+        {
+            get => _length;
+            set
+            {
+                if (_length == value)
+                    return;
+
+                _length = value;
+                OnPropertyChanged(nameof(Length));
+            }
+        }
+        public string LengthText
+        {
+            get => _lengthText;
+            set
+            {
+                if (_lengthText == value)
+                    return;
+
+                _lengthText = value;
+                OnPropertyChanged(nameof(LengthText));
+
+                ValidateLengthInput(value);
+            }
+        }
+        public string LengthError
+        {
+            get => _lengthError;
+            set
+            {
+                if (_lengthError == value)
+                    return;
+
+                _lengthError = value;
+                OnPropertyChanged(nameof(LengthError));
+            }
+        }
+        public string CharsetsError
+        {
+            get => _charsetsError;
+            set
+            {
+                if (_charsetsError == value)
+                    return;
+
+                _charsetsError = value;
+                OnPropertyChanged(nameof(CharsetsError));
+            }
+        }
+
+
+        public bool UseUppercase
+        {
+            get => _useUppercase;
+            set
+            {
+                if (_useUppercase == value)
+                    return;
+
+                _useUppercase = value;
+                OnPropertyChanged(nameof(UseUppercase));
+            }
+        }
+
+        public bool UseLowercase
+        {
+            get => _useLowercase;
+            set
+            {
+                if (_useLowercase == value)
+                    return;
+
+                _useLowercase = value;
+                OnPropertyChanged(nameof(UseLowercase));
+            }
+        }
+
+        public bool UseDigits
+        {
+            get => _useDigits;
+            set
+            {
+                if (_useDigits == value)
+                    return;
+
+                _useDigits = value;
+                OnPropertyChanged(nameof(UseDigits));
+            }
+        }
+
+        public bool UseSpecial
+        {
+            get => _useSpecial;
+            set
+            {
+                if (_useSpecial == value)
+                    return;
+
+                _useSpecial = value;
+                OnPropertyChanged(nameof(UseSpecial));
+            }
+        }
+
+        public bool ExcludeAmbiguous
+        {
+            get => _excludeAmbiguous;
+            set
+            {
+                if (_excludeAmbiguous == value)
+                    return;
+
+                _excludeAmbiguous = value;
+                OnPropertyChanged(nameof(ExcludeAmbiguous));
+            }
+        }
 
         public PasswordStrength Strength
         {
             get => _strength;
-            set
+            private set
             {
-                if (_strength != value)
-                {
-                    _strength = value;
-                    OnPropertyChanged(nameof(Strength));
-                    OnPropertyChanged(nameof(StrengthLabel));
-                    OnPropertyChanged(nameof(StrengthBrush));
-                }
+                if (_strength == value)
+                    return;
+
+                _strength = value;
+                OnPropertyChanged(nameof(Strength));
+                OnPropertyChanged(nameof(StrengthLabel));
+                OnPropertyChanged(nameof(StrengthBrush));
             }
         }
+
         public string StrengthLabel =>
             Strength switch
             {
@@ -48,6 +185,7 @@ namespace Pango.Desktop.Uwp.ViewModels
                 PasswordStrength.Strong => ViewResourceLoader.GetString("PasswordStrength_Strong"),
                 _ => string.Empty
             };
+
         public SolidColorBrush StrengthBrush =>
             Strength switch
             {
@@ -56,40 +194,100 @@ namespace Pango.Desktop.Uwp.ViewModels
                 PasswordStrength.Strong => new SolidColorBrush(Colors.Green),
                 _ => new SolidColorBrush(Colors.Gray)
             };
-        #endregion Properties
+
+        #endregion
 
         #region Commands
-        public ICommand GenerateCommand { get; }
-        public ICommand ApplyCommand { get; }
-        public ICommand CancelCommand { get; }
-        public RelayCommand CopyPasswordCommand { get; }
-        public ICommand RegeneratePasswordCommand { get; }
-        #endregion Commands
 
+        public IAsyncRelayCommand GenerateCommand { get; }
+        public IAsyncRelayCommand RegeneratePasswordCommand { get; }
+        public RelayCommand CopyPasswordCommand { get; }
+        public RelayCommand ApplyCommand { get; }
+        public RelayCommand CancelCommand { get; }
+
+        #endregion
+
+        public GeneratePasswordViewModel(ISender sender, ILogger<GeneratePasswordViewModel> logger)
+            : base(logger)
+        {
+            _sender = sender;
+
+            GenerateCommand = new AsyncRelayCommand(GenerateAsync);
+            RegeneratePasswordCommand = new AsyncRelayCommand(GenerateAsync);
+            CopyPasswordCommand = new RelayCommand(CopyPassword, CanCopyPassword);
+            ApplyCommand = new RelayCommand(Apply);
+            CancelCommand = new RelayCommand(Cancel);
+        }
         private async Task GenerateAsync()
         {
-            var command = new GeneratePasswordCommand(Length, UseUppercase, UseLowercase, UseDigits, UseSpecial, ExcludeAmbiguous);
+            if (!ValidateLengthInput(LengthText))
+                return;
+            if (!ValidateCharsets())
+                return;
+            var command = new GeneratePasswordCommand(
+                Length,
+                UseUppercase,
+                UseLowercase,
+                UseDigits,
+                UseSpecial,
+                ExcludeAmbiguous);
+
             var result = await _sender.Send(command);
+
             if (result.IsError)
             {
                 Logger.LogError("Password generation failed: {Errors}", string.Join(", ", result.Errors));
 
-                var message = result.FirstError.Description ?? ViewResourceLoader.GetString("PasswordGenerationFailed");
+                var message = result.FirstError.Description
+                              ?? ViewResourceLoader.GetString("PasswordGenerationFailed");
 
-                WeakReferenceMessenger.Default.Send(new InAppNotificationMessage(message, AppNotificationType.Error));
+                WeakReferenceMessenger.Default.Send(
+                    new InAppNotificationMessage(message, AppNotificationType.Error));
 
                 return;
             }
+
             GeneratedPassword = result.Value;
 
-            WeakReferenceMessenger.Default.Send(new InAppNotificationMessage(ViewResourceLoader.GetString("PasswordGeneratedSuccessfully")));
+            WeakReferenceMessenger.Default.Send(
+                new InAppNotificationMessage(
+                    ViewResourceLoader.GetString("PasswordGeneratedSuccessfully")));
         }
+        private bool ValidateLengthInput(string text)
+        {
+            if (!int.TryParse(text, out var parsed))
+            {
+                LengthError = ViewResourceLoader.GetString("PasswordLength_Invalid");
+                return false;
+            }
 
+            if (parsed < 8 || parsed > 64)
+            {
+                LengthError = ViewResourceLoader.GetString("PasswordLength_OutOfRange");
+                return false;
+            }
+
+            LengthError = string.Empty;
+            Length = parsed;
+            return true;
+        }
+        private bool ValidateCharsets()
+        {
+            if (!UseUppercase && !UseLowercase && !UseDigits && !UseSpecial)
+            {
+                CharsetsError = ViewResourceLoader.GetString("PasswordGeneration_Error_NoCharSet");
+                return false;
+            }
+
+            CharsetsError = string.Empty;
+            return true;
+        }       
         private bool CanCopyPassword() => !string.IsNullOrEmpty(GeneratedPassword);
         private void CopyPassword()
         {
             if (string.IsNullOrEmpty(GeneratedPassword))
                 return;
+
             var dataPackage = new DataPackage
             {
                 RequestedOperation = DataPackageOperation.Copy
@@ -97,16 +295,51 @@ namespace Pango.Desktop.Uwp.ViewModels
             dataPackage.SetText(GeneratedPassword);
             Clipboard.SetContent(dataPackage);
 
-            WeakReferenceMessenger.Default.Send(new InAppNotificationMessage(ViewResourceLoader.GetString("PasswordCopiedToClipboard")));
+            WeakReferenceMessenger.Default.Send(
+                new InAppNotificationMessage(
+                    ViewResourceLoader.GetString("PasswordCopiedToClipboard"),
+                    AppNotificationType.Success));
+        }
+        private void Apply()
+        {
+            // TODO: Implement Cancel functionality
+            Logger.LogInformation(
+                "Apply password clicked with value length {Length}",
+                GeneratedPassword?.Length ?? 0);
         }
 
-        public GeneratePasswordViewModel(ILogger<GeneratePasswordViewModel> logger) : base(logger)
+        private void Cancel()
         {
-            GenerateCommand = new RelayCommand(() => {  });
-            ApplyCommand = new RelayCommand(() => {  });
-            CancelCommand = new RelayCommand(() => {  });
-            CopyPasswordCommand = new RelayCommand(() => {  });
-            RegeneratePasswordCommand = new RelayCommand(() => {  });
+            // TODO: Implement Cancel functionality
+            Logger.LogInformation("Cancel password generation clicked.");
+        }
+        private void UpdateStrength()
+        {
+            var password = GeneratedPassword ?? string.Empty;
+
+            if (password.Length == 0)
+            {
+                Strength = PasswordStrength.Weak;
+                return;
+            }
+
+            int score = 0;
+
+            if (password.Length >= 8) score += 2;
+            if (password.Length >= 12) score += 2;
+            if (password.Length >= 16) score += 2;
+
+            if (ContainsUpper(password)) score += 1;
+            if (ContainsLower(password)) score += 1;
+            if (ContainsDigit(password)) score += 1;
+            if (ContainsSpecial(password)) score += 1;
+
+            if (score <= 3)
+                Strength = PasswordStrength.Weak;
+            else if (score <= 6)
+                Strength = PasswordStrength.Medium;
+            else
+                Strength = PasswordStrength.Strong;
         }
         private static bool ContainsUpper(string s) => s.Any(char.IsUpper);
         private static bool ContainsLower(string s) => s.Any(char.IsLower);

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/GeneratePasswordViewModel.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/GeneratePasswordViewModel.cs
@@ -22,7 +22,6 @@ public sealed class GeneratePasswordViewModel : ViewModelBase
     private readonly ISender _sender;
     private string _generatedPassword = string.Empty;
     private int _length = PasswordConstants.SafeLength;
-    private string _lengthText = PasswordConstants.SafeLength.ToString();
     private string _lengthError;
     private string _charsetsError;
     private bool _useUppercase = true;
@@ -60,20 +59,7 @@ public sealed class GeneratePasswordViewModel : ViewModelBase
 
             _length = value;
             OnPropertyChanged(nameof(Length));
-        }
-    }
-    public string LengthText
-    {
-        get => _lengthText;
-        set
-        {
-            if (_lengthText == value)
-                return;
-
-            _lengthText = value;
-            OnPropertyChanged(nameof(LengthText));
-
-            ValidateLengthInput(value);
+            ValidateLength(value);
         }
     }
     public string LengthError
@@ -237,7 +223,7 @@ public sealed class GeneratePasswordViewModel : ViewModelBase
 
     private async Task GenerateAsync()
     {
-        if (!ValidateLengthInput(LengthText))
+        if (!ValidateLength(Length))
             return;
         if (!ValidateCharsets())
             return;
@@ -270,24 +256,17 @@ public sealed class GeneratePasswordViewModel : ViewModelBase
             new InAppNotificationMessage(
                 ViewResourceLoader.GetString("PasswordGeneratedSuccessfully")));
     }
-    private bool ValidateLengthInput(string text)
+    private bool ValidateLength(int value)
     {
-        if (!int.TryParse(text, out var parsed))
-        {
-            LengthError = ViewResourceLoader.GetString("PasswordLength_Invalid");
-            return false;
-        }
-
-        if (parsed < PasswordConstants.MinLength || parsed > PasswordConstants.MaxLength)
+        if (value < PasswordConstants.MinLength || value > PasswordConstants.MaxLength)
         {
             LengthError = ViewResourceLoader.GetString("PasswordLength_OutOfRange");
             return false;
         }
-
         LengthError = string.Empty;
-        Length = parsed;
         return true;
     }
+
     private bool ValidateCharsets()
     {
         if (!UseUppercase && !UseLowercase && !UseDigits && !UseSpecial)
@@ -350,7 +329,6 @@ public sealed class GeneratePasswordViewModel : ViewModelBase
     {
         GeneratedPassword = string.Empty;
         Length = PasswordConstants.SafeLength;
-        LengthText = PasswordConstants.SafeLength.ToString();
         LengthError = string.Empty;
 
         UseUppercase = true;
@@ -362,7 +340,7 @@ public sealed class GeneratePasswordViewModel : ViewModelBase
         Strength = PasswordStrength.Weak;
     }
 
-     private int CalculatePasswordStrength(string password)
+    private int CalculatePasswordStrength(string password)
     {
         if (string.IsNullOrEmpty(password))
         {
@@ -382,6 +360,12 @@ public sealed class GeneratePasswordViewModel : ViewModelBase
 
         return score;
     }
+    private PasswordStrength GetPasswordStrength(int score)
+    {
+        if (score <= PasswordConstants.WeakThreshold) return PasswordStrength.Weak;
+        if (score <= PasswordConstants.MediumThreshold) return PasswordStrength.Medium;
+        return PasswordStrength.Strong;
+    }
 
     private void UpdateStrength()
     {
@@ -389,8 +373,7 @@ public sealed class GeneratePasswordViewModel : ViewModelBase
 
         var score = CalculatePasswordStrength(password);
 
-        Strength = score <= 3 ? PasswordStrength.Weak :
-            score <= 6 ? PasswordStrength.Medium : PasswordStrength.Strong;
+        Strength = GetPasswordStrength(score);
     }
     private static bool ContainsUpper(string s) => s.Any(char.IsUpper);
     private static bool ContainsLower(string s) => s.Any(char.IsLower);

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/GeneratePasswordViewModel.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/GeneratePasswordViewModel.cs
@@ -17,8 +17,8 @@ namespace Pango.Desktop.Uwp.ViewModels
 {
     public sealed class GeneratePasswordViewModel : ViewModelBase
     {
+        #region Fields
         private readonly ISender _sender;
-
         private string _generatedPassword = string.Empty;
         private int _length = 16;
         private string _lengthText = "16";
@@ -30,6 +30,7 @@ namespace Pango.Desktop.Uwp.ViewModels
         private bool _useSpecial = false;
         private bool _excludeAmbiguous = false;
         private PasswordStrength _strength;
+        #endregion
 
         #region Properties
         public string GeneratedPassword
@@ -223,6 +224,16 @@ namespace Pango.Desktop.Uwp.ViewModels
             CancelCommand = new RelayCommand(Cancel);
             SaveAsCommand = new RelayCommand(SaveAs, CanSaveAs);
         }
+
+        #region Overrides
+        public override async Task OnNavigatedToAsync(object? parameter)
+        {
+            await base.OnNavigatedToAsync(parameter);
+
+            Clear();
+        }
+        #endregion
+
         private async Task GenerateAsync()
         {
             if (!ValidateLengthInput(LengthText))
@@ -318,6 +329,7 @@ namespace Pango.Desktop.Uwp.ViewModels
             // TODO: Implement Cancel functionality
             Logger.LogInformation("Cancel password generation clicked.");
         }
+
         private bool CanSaveAs() => !string.IsNullOrEmpty(GeneratedPassword);
         private void SaveAs()
         {
@@ -332,6 +344,22 @@ namespace Pango.Desktop.Uwp.ViewModels
             // separate message - create new password with generated value
             WeakReferenceMessenger.Default.Send(new CreatePasswordFromGeneratorMessage(GeneratedPassword));
         }
+
+        private void Clear()
+        {
+            GeneratedPassword = string.Empty;
+            Length = 16;
+            LengthText = "16";
+            LengthError = string.Empty;
+
+            UseUppercase = true;
+            UseLowercase = true;
+            UseDigits = true;
+            UseSpecial = false;
+            ExcludeAmbiguous = false;
+
+            Strength = PasswordStrength.Weak;
+        }              
 
         private void UpdateStrength()
         {

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/GeneratePasswordViewModel.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/GeneratePasswordViewModel.cs
@@ -21,8 +21,8 @@ public sealed class GeneratePasswordViewModel : ViewModelBase
     #region Fields
     private readonly ISender _sender;
     private string _generatedPassword = string.Empty;
-    private int _length = 16;
-    private string _lengthText = "16";
+    private int _length = PasswordConstants.SafeLength;
+    private string _lengthText = PasswordConstants.SafeLength.ToString();
     private string _lengthError;
     private string _charsetsError;
     private bool _useUppercase = true;
@@ -349,8 +349,8 @@ public sealed class GeneratePasswordViewModel : ViewModelBase
     private void Clear()
     {
         GeneratedPassword = string.Empty;
-        Length = PasswordConstants.MinLength;
-        LengthText = PasswordConstants.MinLength.ToString();
+        Length = PasswordConstants.SafeLength;
+        LengthText = PasswordConstants.SafeLength.ToString();
         LengthError = string.Empty;
 
         UseUppercase = true;
@@ -362,14 +362,11 @@ public sealed class GeneratePasswordViewModel : ViewModelBase
         Strength = PasswordStrength.Weak;
     }
 
-    private void UpdateStrength()
+     private int CalculatePasswordStrength(string password)
     {
-        var password = GeneratedPassword ?? string.Empty;
-
-        if (password.Length == 0)
+        if (string.IsNullOrEmpty(password))
         {
-            Strength = PasswordStrength.Weak;
-            return;
+            return 0;
         }
 
         int score = 0;
@@ -383,12 +380,17 @@ public sealed class GeneratePasswordViewModel : ViewModelBase
         if (ContainsDigit(password)) score += 1;
         if (ContainsSpecial(password)) score += 1;
 
-        if (score <= 3)
-            Strength = PasswordStrength.Weak;
-        else if (score <= 6)
-            Strength = PasswordStrength.Medium;
-        else
-            Strength = PasswordStrength.Strong;
+        return score;
+    }
+
+    private void UpdateStrength()
+    {
+        var password = GeneratedPassword ?? string.Empty;
+
+        var score = CalculatePasswordStrength(password);
+
+        Strength = score <= 3 ? PasswordStrength.Weak :
+            score <= 6 ? PasswordStrength.Medium : PasswordStrength.Strong;
     }
     private static bool ContainsUpper(string s) => s.Any(char.IsUpper);
     private static bool ContainsLower(string s) => s.Any(char.IsLower);

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/GeneratePasswordViewModel.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/GeneratePasswordViewModel.cs
@@ -6,6 +6,8 @@ using Microsoft.UI;
 using Microsoft.UI.Xaml.Media;
 using Pango.Application.UseCases.Password.Commands.GeneratePassword;
 using Pango.Desktop.Uwp.Core.Enums;
+using Pango.Desktop.Uwp.Models.Parameters;
+using Pango.Desktop.Uwp.Mvvm.Messages;
 using Pango.Desktop.Uwp.Mvvm.Models;
 using System.Linq;
 using System.Threading.Tasks;
@@ -42,6 +44,7 @@ namespace Pango.Desktop.Uwp.ViewModels
                 OnPropertyChanged(nameof(GeneratedPassword));
                 UpdateStrength();
                 CopyPasswordCommand.NotifyCanExecuteChanged();
+                SaveAsCommand.NotifyCanExecuteChanged();
             }
         }
 
@@ -204,6 +207,7 @@ namespace Pango.Desktop.Uwp.ViewModels
         public RelayCommand CopyPasswordCommand { get; }
         public RelayCommand ApplyCommand { get; }
         public RelayCommand CancelCommand { get; }
+        public RelayCommand SaveAsCommand { get; }
 
         #endregion
 
@@ -217,6 +221,7 @@ namespace Pango.Desktop.Uwp.ViewModels
             CopyPasswordCommand = new RelayCommand(CopyPassword, CanCopyPassword);
             ApplyCommand = new RelayCommand(Apply);
             CancelCommand = new RelayCommand(Cancel);
+            SaveAsCommand = new RelayCommand(SaveAs, CanSaveAs);
         }
         private async Task GenerateAsync()
         {
@@ -302,7 +307,7 @@ namespace Pango.Desktop.Uwp.ViewModels
         }
         private void Apply()
         {
-            // TODO: Implement Cancel functionality
+            // TODO: Implement Apply functionality
             Logger.LogInformation(
                 "Apply password clicked with value length {Length}",
                 GeneratedPassword?.Length ?? 0);
@@ -313,6 +318,21 @@ namespace Pango.Desktop.Uwp.ViewModels
             // TODO: Implement Cancel functionality
             Logger.LogInformation("Cancel password generation clicked.");
         }
+        private bool CanSaveAs() => !string.IsNullOrEmpty(GeneratedPassword);
+        private void SaveAs()
+        {
+            if (string.IsNullOrEmpty(GeneratedPassword))
+                return;
+
+            // navigation on PasswordsIndex
+            WeakReferenceMessenger.Default.Send(
+                new NavigationRequstedMessage(
+                    new NavigationParameters(AppView.PasswordsIndex, AppView.GeneratePassword)));
+
+            // separate message - create new password with generated value
+            WeakReferenceMessenger.Default.Send(new CreatePasswordFromGeneratorMessage(GeneratedPassword));
+        }
+
         private void UpdateStrength()
         {
             var password = GeneratedPassword ?? string.Empty;

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/GeneratePasswordViewModel.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/GeneratePasswordViewModel.cs
@@ -1,84 +1,31 @@
 ﻿using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using MediatR;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI;
 using Microsoft.UI.Xaml.Media;
+using Microsoft.VisualBasic;
+using Pango.Application.UseCases.Password.Commands.GeneratePassword;
 using Pango.Desktop.Uwp.Core.Enums;
+using Pango.Desktop.Uwp.Mvvm.Models;
+using System.Linq;
+using System.Threading.Tasks;
 using System.Windows.Input;
+using Windows.ApplicationModel.DataTransfer;
 
 namespace Pango.Desktop.Uwp.ViewModels
 {
     public sealed class GeneratePasswordViewModel : ViewModelBase
     {
         public string GeneratedPassword { get; set; } = string.Empty;
+        public int Length { get; set; } = 16;
 
-        private int _length = 16;
-        public int Length
-        {
-            get => _length;
-            private set
-            {
-                if (_length == value)
-                    return;
-
-                _length = value;
-                OnPropertyChanged(nameof(Length));
-            }
-        }
-
-        private string _lengthText = "16";
-        public string LengthText
-        {
-            get => _lengthText;
-            set
-            {
-                if (_lengthText == value)
-                    return;
-
-                _lengthText = value;
-                OnPropertyChanged(nameof(LengthText));
-
-                ValidateLengthCore(value);
-            }
-        }
-
-        private string _lengthError;
-        public string LengthError
-        {
-            get => _lengthError;
-            set
-            {
-                if (_lengthError == value)
-                    return;
-
-                _lengthError = value;
-                OnPropertyChanged(nameof(LengthError));
-            }
-        }
-
-        private void ValidateLengthCore(string text)
-        {
-            if (!int.TryParse(text, out var parsed))
-            {
-                LengthError = ViewResourceLoader.GetString("PasswordLength_Invalid");
-                return;
-            }
-
-            if (parsed < 8 || parsed > 64)
-            {
-                LengthError = ViewResourceLoader.GetString("PasswordLength_OutOfRange");
-                return;
-            }
-
-            LengthError = string.Empty;
-            Length = parsed;
-        }
         public bool UseUppercase { get; set; } = true;
         public bool UseLowercase { get; set; } = true;
         public bool UseDigits { get; set; } = true;
         public bool UseSpecial { get; set; } = false;
         public bool ExcludeAmbiguous { get; set; } = false;
 
-        private PasswordStrength _strength;
         public PasswordStrength Strength
         {
             get => _strength;
@@ -109,21 +56,62 @@ namespace Pango.Desktop.Uwp.ViewModels
                 PasswordStrength.Strong => new SolidColorBrush(Colors.Green),
                 _ => new SolidColorBrush(Colors.Gray)
             };
+        #endregion Properties
 
+        #region Commands
         public ICommand GenerateCommand { get; }
         public ICommand ApplyCommand { get; }
         public ICommand CancelCommand { get; }
-        public ICommand CopyPasswordCommand { get; }
+        public RelayCommand CopyPasswordCommand { get; }
         public ICommand RegeneratePasswordCommand { get; }
+        #endregion Commands
+
+        private async Task GenerateAsync()
+        {
+            var command = new GeneratePasswordCommand(Length, UseUppercase, UseLowercase, UseDigits, UseSpecial, ExcludeAmbiguous);
+            var result = await _sender.Send(command);
+            if (result.IsError)
+            {
+                Logger.LogError("Password generation failed: {Errors}", string.Join(", ", result.Errors));
+
+                var message = result.FirstError.Description ?? ViewResourceLoader.GetString("PasswordGenerationFailed");
+
+                WeakReferenceMessenger.Default.Send(new InAppNotificationMessage(message, AppNotificationType.Error));
+
+                return;
+            }
+            GeneratedPassword = result.Value;
+
+            WeakReferenceMessenger.Default.Send(new InAppNotificationMessage(ViewResourceLoader.GetString("PasswordGeneratedSuccessfully")));
+        }
+
+        private bool CanCopyPassword() => !string.IsNullOrEmpty(GeneratedPassword);
+        private void CopyPassword()
+        {
+            if (string.IsNullOrEmpty(GeneratedPassword))
+                return;
+            var dataPackage = new DataPackage
+            {
+                RequestedOperation = DataPackageOperation.Copy
+            };
+            dataPackage.SetText(GeneratedPassword);
+            Clipboard.SetContent(dataPackage);
+
+            WeakReferenceMessenger.Default.Send(new InAppNotificationMessage(ViewResourceLoader.GetString("PasswordCopiedToClipboard")));
+        }
 
         public GeneratePasswordViewModel(ILogger<GeneratePasswordViewModel> logger) : base(logger)
         {
-            GenerateCommand = new RelayCommand(() => { });
-            ApplyCommand = new RelayCommand(() => { });
-            CancelCommand = new RelayCommand(() => { });
-            CopyPasswordCommand = new RelayCommand(() => { });
-            RegeneratePasswordCommand = new RelayCommand(() => { });
+            GenerateCommand = new RelayCommand(() => {  });
+            ApplyCommand = new RelayCommand(() => {  });
+            CancelCommand = new RelayCommand(() => {  });
+            CopyPasswordCommand = new RelayCommand(() => {  });
+            RegeneratePasswordCommand = new RelayCommand(() => {  });
         }
+        private static bool ContainsUpper(string s) => s.Any(char.IsUpper);
+        private static bool ContainsLower(string s) => s.Any(char.IsLower);
+        private static bool ContainsDigit(string s) => s.Any(char.IsDigit);
+        private static bool ContainsSpecial(string s) => s.Any(c => !char.IsLetterOrDigit(c));
     }
 
 }

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/PasswordsViewModel.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/PasswordsViewModel.cs
@@ -37,6 +37,8 @@ public sealed class PasswordsViewModel : ViewModelBase
     private PangoExplorerItem? _selectedItem;
     private ObservableCollection<PangoExplorerItem> _originalList;
     private string _searchText = string.Empty;
+    private bool _isLoaded;
+    private string? _pendingGeneratedPassword;
 
     public PasswordsViewModel(ISender sender, IDialogService dialogService, ILogger<PasswordsViewModel> logger) : base(logger)
     {
@@ -117,12 +119,20 @@ public sealed class PasswordsViewModel : ViewModelBase
         WeakReferenceMessenger.Default.Register<PasswordUpdatedMessage>(this, OnPasswordUpdatedAsync);
         WeakReferenceMessenger.Default.Register<CreatePasswordFromGeneratorMessage>(this, OnCreatePasswordFromGenerator);
     }
-
+    
     public override async Task OnNavigatedToAsync(object? parameter)
     {
         await base.OnNavigatedToAsync(parameter);
 
         await ResetViewAsync();
+        _isLoaded = true;
+
+        // if the password from the generator has already been received during the download, we will process it now
+        if (!string.IsNullOrEmpty(_pendingGeneratedPassword))
+        {
+            OpenEditForGeneratedPassword(_pendingGeneratedPassword);
+            _pendingGeneratedPassword = null;
+        }
     }
 
     #endregion
@@ -160,8 +170,15 @@ public sealed class PasswordsViewModel : ViewModelBase
 
     private void OnCreatePasswordFromGenerator(object recipient, CreatePasswordFromGeneratorMessage message)
     {
-        WeakReferenceMessenger.Default.Send(new NavigationRequstedMessage(new NavigationParameters(AppView.EditPassword, AppView.PasswordsIndex, new EditPasswordParameters(true, GetPathToSelectedFolder(), null, GetAvailableCatalogs(), message.Value))));
+        if (!_isLoaded)
+        {
+            // save password and leave
+            _pendingGeneratedPassword = message.Value;
+            return;
+        }
+        OpenEditForGeneratedPassword(message.Value);
     }
+    
     private async void OnCopyPasswordToClipboard(PangoExplorerItem? dto)
     {
         if(dto is null)
@@ -684,5 +701,23 @@ public sealed class PasswordsViewModel : ViewModelBase
             SelectedItem.CatalogPath + (string.IsNullOrEmpty(SelectedItem.CatalogPath) ? string.Empty : AppConstants.CatalogDelimeter) + SelectedItem.Name :
             SelectedItem.CatalogPath;
 
+    /// <summary>
+    /// Opens EditPasswordView with generated password value
+    /// </summary>
+    /// <returns></returns>
+    private void OpenEditForGeneratedPassword(string generatedPassword)
+    {
+        WeakReferenceMessenger.Default.Send(
+            new NavigationRequstedMessage(
+                new NavigationParameters(
+                    AppView.EditPassword,
+                    AppView.PasswordsIndex,
+                    new EditPasswordParameters(
+                        isNew: true,
+                        catalog: GetPathToSelectedFolder(),
+                        selectedPasswordId: null,
+                        availableCatalogs: GetAvailableCatalogs(),
+                        generatedPassword: generatedPassword))));
+    }
     #endregion
 }

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/PasswordsViewModel.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/ViewModels/PasswordsViewModel.cs
@@ -115,6 +115,7 @@ public sealed class PasswordsViewModel : ViewModelBase
 
         WeakReferenceMessenger.Default.Register<PasswordCreatedMessage>(this, OnPasswordCreated);
         WeakReferenceMessenger.Default.Register<PasswordUpdatedMessage>(this, OnPasswordUpdatedAsync);
+        WeakReferenceMessenger.Default.Register<CreatePasswordFromGeneratorMessage>(this, OnCreatePasswordFromGenerator);
     }
 
     public override async Task OnNavigatedToAsync(object? parameter)
@@ -157,6 +158,10 @@ public sealed class PasswordsViewModel : ViewModelBase
         await ResetViewAsync();
     }
 
+    private void OnCreatePasswordFromGenerator(object recipient, CreatePasswordFromGeneratorMessage message)
+    {
+        WeakReferenceMessenger.Default.Send(new NavigationRequstedMessage(new NavigationParameters(AppView.EditPassword, AppView.PasswordsIndex, new EditPasswordParameters(true, GetPathToSelectedFolder(), null, GetAvailableCatalogs(), message.Value))));
+    }
     private async void OnCopyPasswordToClipboard(PangoExplorerItem? dto)
     {
         if(dto is null)

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/GeneratePasswordView.xaml
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/GeneratePasswordView.xaml
@@ -114,8 +114,9 @@
                             </Grid.ColumnDefinitions>
 
                             <TextBox x:Name="LengthTextBox"
-                                 Text="{Binding LengthText,
+                                 Text="{Binding Length,
                                                 Mode=TwoWay,
+                                                Converter={StaticResource IntToStringConverter},
                                                 UpdateSourceTrigger=LostFocus}"
                                  Style="{StaticResource BodyTextBlockStyle}"
                                  VerticalContentAlignment="Center"

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/GeneratePasswordView.xaml
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/GeneratePasswordView.xaml
@@ -208,13 +208,6 @@
                             Command="{Binding SaveAsCommand}"
                             Visibility="{Binding GeneratedPassword,
                               Converter={StaticResource StringToVisibilityConverter}}"/>
-                    <!-- <Button Content="{loc:StringResource Key=Apply}"
-                            Margin="0,0,8,0"
-                            Style="{StaticResource AccentButtonStyle}"
-                            Command="{Binding ApplyCommand}"/>
-                    <Button Content="{loc:StringResource Key=Cancel}"
-                            Style="{StaticResource DefaultButtonStyle}"
-                            Command="{Binding CancelCommand}"/> -->
                 </StackPanel>
             </Grid>
         </Grid>

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/GeneratePasswordView.xaml
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/GeneratePasswordView.xaml
@@ -202,13 +202,19 @@
                             Margin="0,0,8,0"
                             Style="{StaticResource DefaultButtonStyle}"
                             Command="{Binding GenerateCommand}"/>
-                    <Button Content="{loc:StringResource Key=Apply}"
+                    <Button Content="{loc:StringResource Key=SaveAs}"
+                            Margin="0,0,8,0"
+                            Style="{StaticResource AccentButtonStyle}"
+                            Command="{Binding SaveAsCommand}"
+                            Visibility="{Binding GeneratedPassword,
+                              Converter={StaticResource StringToVisibilityConverter}}"/>
+                    <!-- <Button Content="{loc:StringResource Key=Apply}"
                             Margin="0,0,8,0"
                             Style="{StaticResource AccentButtonStyle}"
                             Command="{Binding ApplyCommand}"/>
                     <Button Content="{loc:StringResource Key=Cancel}"
                             Style="{StaticResource DefaultButtonStyle}"
-                            Command="{Binding CancelCommand}"/>
+                            Command="{Binding CancelCommand}"/> -->
                 </StackPanel>
             </Grid>
         </Grid>

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/GeneratePasswordView.xaml
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/GeneratePasswordView.xaml
@@ -163,11 +163,9 @@
                                 Margin="0,4">
                         <CheckBox Content="{loc:StringResource Key=UseUppercase}"
                                   IsChecked="{Binding UseUppercase}"
-                                  ToolTipService.ToolTip="{loc:StringResource Key=UseUppercaseTooltip}"
                                   Margin="0,0,16,0"/>
                         <CheckBox Content="{loc:StringResource Key=UseLowercase}"
                                   IsChecked="{Binding UseLowercase}"
-                                  ToolTipService.ToolTip="{loc:StringResource Key=UseLowercaseTooltip}"
                                   Margin="0,0,16,0"/>
                     </StackPanel>
 
@@ -175,16 +173,13 @@
                                 Margin="0,4">
                         <CheckBox Content="{loc:StringResource Key=UseDigits}"
                                   IsChecked="{Binding UseDigits}"
-                                  ToolTipService.ToolTip="{loc:StringResource Key=UseDigitsTooltip}"
                                   Margin="0,0,16,0"/>
                         <CheckBox Content="{loc:StringResource Key=UseSpecial}"
-                                  ToolTipService.ToolTip="{loc:StringResource Key=UseSpecialTooltip}"
                                   IsChecked="{Binding UseSpecial}"/>
                     </StackPanel>
 
                     <CheckBox Margin="0,8,0,0"
                               Content="{loc:StringResource Key=ExcludeAmbiguousCharacters}"
-                              ToolTipService.ToolTip="{loc:StringResource Key=ExcludeAmbiguousTooltip}"
                               IsChecked="{Binding ExcludeAmbiguous}"/>
                 </StackPanel>
 

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/GeneratePasswordView.xaml
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/GeneratePasswordView.xaml
@@ -96,12 +96,9 @@
                       Margin="0,4,0,0">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
-                        <!-- Label + input -->
                         <RowDefinition Height="Auto"/>
-                        <!-- Error text (фиксированное место) -->
                     </Grid.RowDefinitions>
 
-                    <!-- Label + input в первой строке -->
                     <StackPanel Grid.Row="0"
                         Orientation="Horizontal"
                         VerticalAlignment="Center">
@@ -139,8 +136,8 @@
                                Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"/>
                         </Grid>
                     </StackPanel>
-
-                    <!-- Ошибка во второй строке: место под неё всегда есть -->
+                    
+                    <!-- error message -->
                     <TextBlock Grid.Row="1"
                        Text="{Binding LengthError}"
                        Style="{StaticResource CaptionTextBlockStyle}"
@@ -162,25 +159,38 @@
                     <StackPanel Orientation="Horizontal"
                                 Margin="0,4">
                         <CheckBox Content="{loc:StringResource Key=UseUppercase}"
-                                  IsChecked="{Binding UseUppercase}"
+                                  IsChecked="{Binding UseUppercase, Mode=TwoWay}"
+                                  ToolTipService.ToolTip="{loc:StringResource Key=UseUppercaseTooltip}"
                                   Margin="0,0,16,0"/>
                         <CheckBox Content="{loc:StringResource Key=UseLowercase}"
-                                  IsChecked="{Binding UseLowercase}"
+                                  IsChecked="{Binding UseLowercase, Mode=TwoWay}"
+                                  ToolTipService.ToolTip="{loc:StringResource Key=UseLowercaseTooltip}"
                                   Margin="0,0,16,0"/>
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal"
                                 Margin="0,4">
                         <CheckBox Content="{loc:StringResource Key=UseDigits}"
-                                  IsChecked="{Binding UseDigits}"
+                                  IsChecked="{Binding UseDigits, Mode=TwoWay}"
+                                  ToolTipService.ToolTip="{loc:StringResource Key=UseDigitsTooltip}"
                                   Margin="0,0,16,0"/>
                         <CheckBox Content="{loc:StringResource Key=UseSpecial}"
-                                  IsChecked="{Binding UseSpecial}"/>
+                                  ToolTipService.ToolTip="{loc:StringResource Key=UseSpecialTooltip}"
+                                  IsChecked="{Binding UseSpecial, Mode=TwoWay}"/>
                     </StackPanel>
 
                     <CheckBox Margin="0,8,0,0"
                               Content="{loc:StringResource Key=ExcludeAmbiguousCharacters}"
-                              IsChecked="{Binding ExcludeAmbiguous}"/>
+                              ToolTipService.ToolTip="{loc:StringResource Key=ExcludeAmbiguousTooltip}"
+                              IsChecked="{Binding ExcludeAmbiguous, Mode=TwoWay}"/>
+                    
+                    <!-- error message -->
+                    <TextBlock Text="{Binding CharsetsError}"
+                       Style="{StaticResource CaptionTextBlockStyle}"
+                       Foreground="Red"
+                       Margin="0,4,0,0"
+                       Visibility="{Binding CharsetsError,
+                                    Converter={StaticResource StringToVisibilityConverter}}"/>
                 </StackPanel>
 
                 <!-- main buttons -->

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/GeneratePasswordView.xaml.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/GeneratePasswordView.xaml.cs
@@ -10,34 +10,33 @@ using Pango.Desktop.Uwp.Views.Abstract;
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 
-namespace Pango.Desktop.Uwp.Views
-{
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
-    [AppView(Core.Enums.AppView.GeneratePassword)]
-    public sealed partial class GeneratePasswordView : PageBase
-    {
-        public GeneratePasswordView()
-            : base(App.Host.Services.GetRequiredService<ILogger<GeneratePasswordView>>())
-        {
-            InitializeComponent();
-            DataContext = App.Host.Services.GetRequiredService<GeneratePasswordViewModel>();
-        }
+namespace Pango.Desktop.Uwp.Views;
 
-        protected override void RegisterMessages()
-        {
-            base.RegisterMessages();
-            WeakReferenceMessenger.Default.Register<GeneratePasswordView, NavigationRequstedMessage>(this, (recipient, message) => recipient.OnNavigationRequested(recipient, message));
-        }
-        protected override void UnregisterMessages()
-        {
-            base.UnregisterMessages();
-            WeakReferenceMessenger.Default.Unregister<NavigationRequstedMessage>(this);
-        }
-        private void OnNavigationRequested(object recipient, NavigationRequstedMessage message)
-        {
-            
-        }
+/// <summary>
+/// An empty page that can be used on its own or navigated to within a Frame.
+/// </summary>
+[AppView(Core.Enums.AppView.GeneratePassword)]
+public sealed partial class GeneratePasswordView : PageBase
+{
+    public GeneratePasswordView()
+        : base(App.Host.Services.GetRequiredService<ILogger<GeneratePasswordView>>())
+    {
+        InitializeComponent();
+        DataContext = App.Host.Services.GetRequiredService<GeneratePasswordViewModel>();
+    }
+
+    protected override void RegisterMessages()
+    {
+        base.RegisterMessages();
+        WeakReferenceMessenger.Default.Register<GeneratePasswordView, NavigationRequstedMessage>(this, (recipient, message) => recipient.OnNavigationRequested(recipient, message));
+    }
+    protected override void UnregisterMessages()
+    {
+        base.UnregisterMessages();
+        WeakReferenceMessenger.Default.Unregister<NavigationRequstedMessage>(this);
+    }
+    private void OnNavigationRequested(object recipient, NavigationRequstedMessage message)
+    {
+
     }
 }

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/GeneratePasswordView.xaml.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/GeneratePasswordView.xaml.cs
@@ -1,7 +1,9 @@
+using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
 using Pango.Desktop.Uwp.Core.Attributes;
+using Pango.Desktop.Uwp.Mvvm.Messages;
 using Pango.Desktop.Uwp.ViewModels;
 using Pango.Desktop.Uwp.Views.Abstract;
 
@@ -20,9 +22,22 @@ namespace Pango.Desktop.Uwp.Views
             : base(App.Host.Services.GetRequiredService<ILogger<GeneratePasswordView>>())
         {
             InitializeComponent();
-
-            // Temporarily - just take the VM from DI
             DataContext = App.Host.Services.GetRequiredService<GeneratePasswordViewModel>();
+        }
+
+        protected override void RegisterMessages()
+        {
+            base.RegisterMessages();
+            WeakReferenceMessenger.Default.Register<GeneratePasswordView, NavigationRequstedMessage>(this, (recipient, message) => recipient.OnNavigationRequested(recipient, message));
+        }
+        protected override void UnregisterMessages()
+        {
+            base.UnregisterMessages();
+            WeakReferenceMessenger.Default.Unregister<NavigationRequstedMessage>(this);
+        }
+        private void OnNavigationRequested(object recipient, NavigationRequstedMessage message)
+        {
+            
         }
     }
 }

--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/MainAppView.xaml.cs
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Views/MainAppView.xaml.cs
@@ -52,6 +52,8 @@ public sealed partial class MainAppView : ViewBase
 
     private async void MainAppView_Loaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
     {
+        OnNavigatedTo(null);
+
         if (ViewModel != null)
         {
             await ViewModel.OnNavigatedToAsync(null);
@@ -124,5 +126,34 @@ public sealed partial class MainAppView : ViewBase
         }
 
         _initialView = null;
+    }
+    protected override void RegisterMessages()
+    {
+        base.RegisterMessages();
+        WeakReferenceMessenger.Default.Register<NavigationRequstedMessage>(this, OnNavigationRequested);
+    }
+
+    protected override void UnregisterMessages()
+    {
+        base.UnregisterMessages();
+        WeakReferenceMessenger.Default.Unregister<NavigationRequstedMessage>(this);
+    }
+
+    private void OnNavigationRequested(object recipient, NavigationRequstedMessage message)
+    {
+        switch (message.Value.NavigatedView)
+        {
+            case AppView.PasswordsIndex:
+                NavigationFrame.Navigate(typeof(PasswordsView));
+                NavigationView.SelectedItem =
+                    NavigationItems.First(i => i.PageType == typeof(PasswordsView)).Item;
+                break;
+
+            case AppView.GeneratePassword:
+                NavigationFrame.Navigate(typeof(GeneratePasswordView));
+                NavigationView.SelectedItem =
+                    NavigationItems.First(i => i.PageType == typeof(GeneratePasswordView)).Item;
+                break;
+        }
     }
 }

--- a/tests/Pango.Infrastructure.Tests/PasswordGeneratorTests.cs
+++ b/tests/Pango.Infrastructure.Tests/PasswordGeneratorTests.cs
@@ -34,20 +34,20 @@ namespace Pango.Infrastructure.Tests
         [InlineData(16)]
         [InlineData(32)]
         [InlineData(64)]
-        public async Task GeneratePassword_LengthIsRespected(int length)
+        public async Task GeneratePasswordAsync_LengthIsRespected(int length)
         {
             // Arrange
             var options = CreateOptions(length: length);
 
             // Act
-            var password = await _passwordGenerator.GeneratePassword(options);
+            var password = await _passwordGenerator.GeneratePasswordAsync(options);
 
             // Assert
             Assert.Equal(length, password.Length);
         }
 
         [Fact]
-        public async Task GeneratePassword_UppercaseOnly_ContainsOnlyUppercase()
+        public async Task GeneratePasswordAsync_UppercaseOnly_ContainsOnlyUppercase()
         {
             // Arrange
             var options = CreateOptions(
@@ -58,7 +58,7 @@ namespace Pango.Infrastructure.Tests
                 useSpecial: false);
 
             // Act
-            var password = await _passwordGenerator.GeneratePassword(options);
+            var password = await _passwordGenerator.GeneratePasswordAsync(options);
 
             // Assert
             Assert.NotEmpty(password);
@@ -66,7 +66,7 @@ namespace Pango.Infrastructure.Tests
         }
 
         [Fact]
-        public async Task GeneratePassword_LowercaseOnly_ContainsOnlyLowercase()
+        public async Task GeneratePasswordAsync_LowercaseOnly_ContainsOnlyLowercase()
         {
             var options = CreateOptions(
                 length: 16,
@@ -75,13 +75,13 @@ namespace Pango.Infrastructure.Tests
                 useDigits: false,
                 useSpecial: false);
 
-            var password = await _passwordGenerator.GeneratePassword(options);
+            var password = await _passwordGenerator.GeneratePasswordAsync(options);
 
             Assert.NotEmpty(password);
             Assert.All(password, c => Assert.InRange(c, 'a', 'z'));
         }
         [Fact]
-        public async Task GeneratePassword_DigitsOnly_ContainsOnlyDigits()
+        public async Task GeneratePasswordAsync_DigitsOnly_ContainsOnlyDigits()
         {
             var options = CreateOptions(
                 length: 16,
@@ -90,13 +90,13 @@ namespace Pango.Infrastructure.Tests
                 useDigits: true,
                 useSpecial: false);
 
-            var password = await _passwordGenerator.GeneratePassword(options);
+            var password = await _passwordGenerator.GeneratePasswordAsync(options);
 
             Assert.NotEmpty(password);
             Assert.All(password, c => Assert.InRange(c, '0', '9'));
         }
         [Fact]
-        public async Task GeneratePassword_UpperLowerDigits_ContainsAllSelectedTypes()
+        public async Task GeneratePasswordAsync_UpperLowerDigits_ContainsAllSelectedTypes()
         {
             var options = CreateOptions(
                 length: 16,
@@ -105,7 +105,7 @@ namespace Pango.Infrastructure.Tests
                 useDigits: true,
                 useSpecial: false);
 
-            var password = await _passwordGenerator.GeneratePassword(options);
+            var password = await _passwordGenerator.GeneratePasswordAsync(options);
 
             Assert.NotEmpty(password);
             Assert.Contains(password, char.IsUpper);
@@ -113,7 +113,7 @@ namespace Pango.Infrastructure.Tests
             Assert.Contains(password, char.IsDigit);
         }
         [Fact]
-        public async Task GeneratePassword_SpecialIncluded_ContainsAtLeastOneSpecial()
+        public async Task GeneratePasswordAsync_SpecialIncluded_ContainsAtLeastOneSpecial()
         {
             var options = CreateOptions(
                 length: 16,
@@ -122,7 +122,7 @@ namespace Pango.Infrastructure.Tests
                 useDigits: false,
                 useSpecial: true);
 
-            var password = await _passwordGenerator.GeneratePassword(options);
+            var password = await _passwordGenerator.GeneratePasswordAsync(options);
 
             Assert.NotEmpty(password);
 
@@ -130,7 +130,7 @@ namespace Pango.Infrastructure.Tests
             Assert.Contains(password, c => special.Contains(c));
         }
         [Fact]
-        public async Task GeneratePassword_ExcludeAmbiguous_RemovesAmbiguousCharacters()
+        public async Task GeneratePasswordAsync_ExcludeAmbiguous_RemovesAmbiguousCharacters()
         {
             var options = CreateOptions(
                 length: 32,
@@ -140,23 +140,47 @@ namespace Pango.Infrastructure.Tests
                 useSpecial: false,
                 excludeAmbiguous: true);
 
-            var password = await _passwordGenerator.GeneratePassword(options);
+            var password = await _passwordGenerator.GeneratePasswordAsync(options);
 
             const string ambiguous = "0O1Il|"; 
 
             Assert.DoesNotContain(password, c => ambiguous.Contains(c));
         }
         [Fact]
-        public async Task GeneratePassword_MultipleCalls_ProduceDifferentPasswords()
+        public async Task GeneratePasswordAsync_MultipleCalls_ProduceDifferentPasswords()
         {
             var options = CreateOptions(length: 16);
 
-            var p1 = await _passwordGenerator.GeneratePassword(options);
-            var p2 = await _passwordGenerator.GeneratePassword(options);
-            var p3 = await _passwordGenerator.GeneratePassword(options);
+            var p1 = await _passwordGenerator.GeneratePasswordAsync(options);
+            var p2 = await _passwordGenerator.GeneratePasswordAsync(options);
+            var p3 = await _passwordGenerator.GeneratePasswordAsync(options);
 
             Assert.False(p1 == p2 && p2 == p3);
         }
 
+        [Fact]
+        public async Task GeneratePasswordAsync_NullOptions_Throws()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+                await _passwordGenerator.GeneratePasswordAsync(null!).AsTask());
+        }
+
+        [Fact]
+        public async Task GeneratePasswordAsync_NonPositiveLength_Throws()
+        {
+            var options = new PasswordGenerationOptions(0, true, false, false, false, false);
+
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+                await _passwordGenerator.GeneratePasswordAsync(options).AsTask());
+        }
+
+        [Fact]
+        public async Task GeneratePasswordAsync_NoCharsAfterFiltering_Throws()
+        {
+            var options = new PasswordGenerationOptions(10, false, false, false, false, true);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await _passwordGenerator.GeneratePasswordAsync(options).AsTask());
+        }
     }
 }

--- a/tests/Pango.Infrastructure.Tests/PasswordGeneratorTests.cs
+++ b/tests/Pango.Infrastructure.Tests/PasswordGeneratorTests.cs
@@ -1,0 +1,162 @@
+﻿using Pango.Application.Common;
+using Pango.Infrastructure.Services;
+
+namespace Pango.Infrastructure.Tests
+{
+    public class PasswordGeneratorTests
+    {
+        private readonly PasswordGenerator _passwordGenerator;
+
+        public PasswordGeneratorTests()
+        {
+            _passwordGenerator = new PasswordGenerator();
+        }
+
+        private PasswordGenerationOptions CreateOptions(
+            int length = 16,
+            bool useUpper = true,
+            bool useLower = true,
+            bool useDigits = true,
+            bool useSpecial = false,
+            bool excludeAmbiguous = false)
+        {
+            return new PasswordGenerationOptions(
+                length,
+                useUpper,
+                useLower,
+                useDigits,
+                useSpecial,
+                excludeAmbiguous);
+        }
+
+        [Theory]
+        [InlineData(8)]
+        [InlineData(16)]
+        [InlineData(32)]
+        [InlineData(64)]
+        public async Task GeneratePassword_LengthIsRespected(int length)
+        {
+            // Arrange
+            var options = CreateOptions(length: length);
+
+            // Act
+            var password = await _passwordGenerator.GeneratePassword(options);
+
+            // Assert
+            Assert.Equal(length, password.Length);
+        }
+
+        [Fact]
+        public async Task GeneratePassword_UppercaseOnly_ContainsOnlyUppercase()
+        {
+            // Arrange
+            var options = CreateOptions(
+                length: 16,
+                useUpper: true,
+                useLower: false,
+                useDigits: false,
+                useSpecial: false);
+
+            // Act
+            var password = await _passwordGenerator.GeneratePassword(options);
+
+            // Assert
+            Assert.NotEmpty(password);
+            Assert.All(password, c => Assert.InRange(c, 'A', 'Z'));
+        }
+
+        [Fact]
+        public async Task GeneratePassword_LowercaseOnly_ContainsOnlyLowercase()
+        {
+            var options = CreateOptions(
+                length: 16,
+                useUpper: false,
+                useLower: true,
+                useDigits: false,
+                useSpecial: false);
+
+            var password = await _passwordGenerator.GeneratePassword(options);
+
+            Assert.NotEmpty(password);
+            Assert.All(password, c => Assert.InRange(c, 'a', 'z'));
+        }
+        [Fact]
+        public async Task GeneratePassword_DigitsOnly_ContainsOnlyDigits()
+        {
+            var options = CreateOptions(
+                length: 16,
+                useUpper: false,
+                useLower: false,
+                useDigits: true,
+                useSpecial: false);
+
+            var password = await _passwordGenerator.GeneratePassword(options);
+
+            Assert.NotEmpty(password);
+            Assert.All(password, c => Assert.InRange(c, '0', '9'));
+        }
+        [Fact]
+        public async Task GeneratePassword_UpperLowerDigits_ContainsAllSelectedTypes()
+        {
+            var options = CreateOptions(
+                length: 16,
+                useUpper: true,
+                useLower: true,
+                useDigits: true,
+                useSpecial: false);
+
+            var password = await _passwordGenerator.GeneratePassword(options);
+
+            Assert.NotEmpty(password);
+            Assert.Contains(password, char.IsUpper);
+            Assert.Contains(password, char.IsLower);
+            Assert.Contains(password, char.IsDigit);
+        }
+        [Fact]
+        public async Task GeneratePassword_SpecialIncluded_ContainsAtLeastOneSpecial()
+        {
+            var options = CreateOptions(
+                length: 16,
+                useUpper: false,
+                useLower: false,
+                useDigits: false,
+                useSpecial: true);
+
+            var password = await _passwordGenerator.GeneratePassword(options);
+
+            Assert.NotEmpty(password);
+
+            const string special = "!@#$%^&*()-_=+[]{};:,.<>/?"; 
+            Assert.Contains(password, c => special.Contains(c));
+        }
+        [Fact]
+        public async Task GeneratePassword_ExcludeAmbiguous_RemovesAmbiguousCharacters()
+        {
+            var options = CreateOptions(
+                length: 32,
+                useUpper: true,
+                useLower: true,
+                useDigits: true,
+                useSpecial: false,
+                excludeAmbiguous: true);
+
+            var password = await _passwordGenerator.GeneratePassword(options);
+
+            const string ambiguous = "0O1Il|"; 
+
+            Assert.DoesNotContain(password, c => ambiguous.Contains(c));
+        }
+        [Fact]
+        public async Task GeneratePassword_MultipleCalls_ProduceDifferentPasswords()
+        {
+            var options = CreateOptions(length: 16);
+
+            var p1 = await _passwordGenerator.GeneratePassword(options);
+            var p2 = await _passwordGenerator.GeneratePassword(options);
+            var p3 = await _passwordGenerator.GeneratePassword(options);
+
+            Assert.False(p1 == p2 && p2 == p3);
+        }
+
+    }
+}


### PR DESCRIPTION
feat: add password saving from generator via "Save As" button

- Add "Save As" button to password generator page
- Implement `CreatePasswordFromGeneratorMessage` for cross-page communication  
- Enable navigation from generator to EditPassword with pre-filled password
- Ensure folder list loads properly on first EditPassword opening

ref: #84 