### PR TITLE
Fix/password overlap 2.0

### DIFF
--- a/src/Presentation/Desktop/Pango.Desktop.Uwp/Controls/ValidationPasswordBox.xaml
+++ b/src/Presentation/Desktop/Pango.Desktop.Uwp/Controls/ValidationPasswordBox.xaml
@@ -330,10 +330,8 @@
                             <RowDefinition Height="Auto"/> <!-- Password -->
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="64" />
-                            <ColumnDefinition Width="20" />
-                        </Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="20"/>                        </Grid.ColumnDefinitions>
                         <ContentPresenter
                             Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3"
                             Content="{TemplateBinding HeaderText}"
@@ -343,34 +341,47 @@
                             TextWrapping="Wrap"
                             VerticalAlignment="Top"
                             IsTabStop="False"/>
-                        <Border x:Name="BorderElement"
-                            Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
-                            BorderBrush="{ThemeResource TextControlBorderBrush}"
-                            BorderThickness="{ThemeResource TextControlBorderThemeThickness}"
-                            Background="{ThemeResource TextControlBackground}"
-                            CornerRadius="{ThemeResource ControlCornerRadius}"
-                            MinHeight="{ThemeResource TextControlThemeMinHeight}"
-                            IsTabStop="False"/>
-                        <PasswordBox
-                            Name="PART_PasswordBox"
-                            Grid.Row="1" Grid.Column="0"
-                            HorizontalAlignment="Stretch"
-                            IsEnabled="{Binding IsReadOnly, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource BoolReverseConverter}}"                            
-                            Style="{StaticResource DefaultPasswordBoxStyle}"
-                            PlaceholderText="{TemplateBinding PlaceholderText}"
-                            Password="{TemplateBinding Password}"
-                            BorderThickness="0"
-                            Background="Transparent">
-                        </PasswordBox>
 
-                        <StackPanel Orientation="Horizontal" Grid.Row="1" Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Stretch"  IsTabStop="False">
-                            <Button x:Name="CopyButton" Style="{StaticResource CopyButtonStyle}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{StaticResource PasswordBoxButtonCornerRadius}" Padding="{ThemeResource HelperButtonThemePadding}" IsTabStop="False" Visibility="Visible" AutomationProperties.AccessibilityView="Raw" FontSize="{TemplateBinding FontSize}" Width="32" Height="32" VerticalAlignment="Center" />
-                            <ToggleButton x:Name="RevealButton" Style="{StaticResource RevealButtonStyle}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{StaticResource PasswordBoxButtonCornerRadius}" Padding="{ThemeResource HelperButtonThemePadding}" IsTabStop="False" Visibility="Visible" FontSize="{TemplateBinding FontSize}" VerticalAlignment="Center" Width="32" Height="32"/>
-                        </StackPanel>
-                        
+                        <Grid Grid.Row="1" Grid.Column="0">
+
+                            <Border
+                                x:Name="BorderElement"
+                                BorderBrush="{ThemeResource TextControlBorderBrush}"
+                                BorderThickness="{ThemeResource TextControlBorderThemeThickness}"
+                                Background="{ThemeResource TextControlBackground}"
+                                CornerRadius="{ThemeResource ControlCornerRadius}"
+                                MinHeight="{ThemeResource TextControlThemeMinHeight}"
+                                IsTabStop="False"/>
+
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+
+                                <PasswordBox
+                                    Name="PART_PasswordBox"
+                                    Grid.Column="0"
+                                    HorizontalAlignment="Stretch"
+                                    IsEnabled="{Binding IsReadOnly, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource BoolReverseConverter}}"                            
+                                    Style="{StaticResource DefaultPasswordBoxStyle}"
+                                    PlaceholderText="{TemplateBinding PlaceholderText}"
+                                    Password="{TemplateBinding Password}"
+                                    BorderThickness="0"
+                                    Background="Transparent"
+                                    Padding="12,8,60,8">
+                                </PasswordBox>
+
+                                <StackPanel Orientation="Horizontal" Grid.Column="0" HorizontalAlignment="Right" VerticalAlignment="Stretch"  IsTabStop="False">
+                                    <Button x:Name="CopyButton" Style="{StaticResource CopyButtonStyle}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{StaticResource PasswordBoxButtonCornerRadius}" Padding="{ThemeResource HelperButtonThemePadding}" IsTabStop="False" Visibility="Visible" AutomationProperties.AccessibilityView="Raw" FontSize="{TemplateBinding FontSize}" Width="32" Height="32" VerticalAlignment="Center" />
+                                    <ToggleButton x:Name="RevealButton" Style="{StaticResource RevealButtonStyle}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{StaticResource PasswordBoxButtonCornerRadius}" Padding="{ThemeResource HelperButtonThemePadding}" IsTabStop="False" Visibility="Visible" FontSize="{TemplateBinding FontSize}" VerticalAlignment="Center" Width="32" Height="32"/>
+                                </StackPanel>
+                            </Grid>
+                        </Grid>
+
                         <FontIcon
                             Name="PART_WarningIcon"
-                            Grid.Row="1" Grid.Column="2"
+                            Grid.Row="1" Grid.Column="1"
                             Margin="0,32,0,0"
                             VerticalAlignment="Center"
                             FontSize="18" 


### PR DESCRIPTION
fix: correct button visibility and focus behavior for password field

- Fix Copy/Reveal buttons not showing when adding password
- Fix highlight area extending behind buttons on focus